### PR TITLE
checkin .travis.yml for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,67 @@
+#https://travis-ci.org/IntelPNI/brainiak
+compiler:
+    - gcc
+    - clang
+
+branches:
+  only:
+    - master
+
+matrix:
+  allow_failures:
+    - os: osx
+
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      python: 3.4
+      language: python
+
+    - os: linux
+      dist: trusty
+      sudo: required    
+      python: 3.5
+      language: python
+
+    - os: osx
+      osx_image: xcode7.1
+      sudo: required
+      language: generic
+      env: HINT=Yosemite MPI=openmpi
+      before_install:
+          - brew update
+          - brew install clang-omp
+          - brew install python3 
+
+
+    - os: osx
+      osx_image: xcode7.3
+      sudo: required
+      language: generic
+      env: HINT=ElCapitan MPI=openmpi
+      before_install:
+          - brew update
+          - brew install clang-omp
+          - brew install python3 
+
+install:
+    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then sudo apt-get -y install build-essential cmake libgomp1 mpich2 python3-pip; fi   
+    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then pip3 install -U pip virtualenv; fi   
+    - if [[ "$TRAVIS_OS_NAME" != "osx" && "$CXX" = "g++" ]]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cmake mpich; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CC="clang-omp"; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export export CXX="clang-omp++"; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip3 install -U pip virtualenv; fi   
+
+script:
+    - ./pr-check.sh pr-check
+
+notifications:
+  webhooks:
+    urls:
+      #- https://webhooks.gitter.im/e/4ffabb4df010b70cd624
+    on_success: change  # options: [always|never|change] default: always
+    on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,49 @@
 #https://travis-ci.org/IntelPNI/brainiak
-compiler:
-    - gcc
-    - clang
-
 branches:
   only:
     - master
 
 matrix:
-  allow_failures:
-    - os: osx
-
   include:
     - os: linux
       dist: trusty
       sudo: required
-      python: 3.4
       language: python
+      python: 3.4
 
     - os: linux
       dist: trusty
       sudo: required    
-      python: 3.5
       language: python
+      python: 3.5
 
     - os: osx
       osx_image: xcode7.1
       sudo: required
       language: generic
-      env: HINT=Yosemite MPI=openmpi
+      env: HINT=Yosemite MPI=mpich
       before_install:
           - brew update
-          - brew install clang-omp
           - brew install python3 
-
 
     - os: osx
       osx_image: xcode7.3
       sudo: required
       language: generic
-      env: HINT=ElCapitan MPI=openmpi
+      env: HINT=ElCapitan MPI=mpich
       before_install:
           - brew update
-          - brew install clang-omp
           - brew install python3 
 
 install:
     - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then sudo apt-get -y install build-essential cmake libgomp1 mpich2 python3-pip; fi   
-    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then pip3 install -U pip virtualenv; fi   
-    - if [[ "$TRAVIS_OS_NAME" != "osx" && "$CXX" = "g++" ]]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cmake mpich; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CC="clang-omp"; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export export CXX="clang-omp++"; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip3 install -U pip virtualenv; fi   
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install llvm mpich; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CC=/usr/local/opt/llvm/bin/clang; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CXX=/usr/local/opt/llvm/bin/clang++; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export LDFLAGS="-L/usr/local/opt/llvm/lib $LDFLAGS"; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CPPFLAGS="-I/usr/local/opt/llvm/include $CPPFLAGS"; fi
+    - pip3 install -U pip virtualenv
 
 script:
     - ./pr-check.sh pr-check
@@ -61,7 +51,8 @@ script:
 notifications:
   webhooks:
     urls:
-      #- https://webhooks.gitter.im/e/4ffabb4df010b70cd624
+      #- https://webhooks.gitter.im/e/TOSETUP
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
+    on_start: never     # options: [always|never|change] default: alwaysfailure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always


### PR DESCRIPTION
testing for linux works. But there's a problem with osx due to the clang-omp removal from brew #84 . (can't brew install clang-omp on travis-ci server). Issue #63 