### PR TITLE
Call `git clean` for docs before building

### DIFF
--- a/pr-check.sh
+++ b/pr-check.sh
@@ -122,6 +122,7 @@ pip3 install $ignore_installed -U -e . || \
 
 # build documentation
 cd docs
+git clean -Xf .
 make || {
     cd -
     exit_with_error_and_venv "make docs failed"


### PR DESCRIPTION
The docs build process leaves behind files that can prevent other branch builds
from succeeding.