### PR TITLE
Rewrite coverage evaluation to work with MPI

### DIFF
--- a/pr-check.sh
+++ b/pr-check.sh
@@ -123,7 +123,11 @@ pip3 install $ignore_installed -U -e . || \
 # build documentation
 cd docs
 git clean -Xf .
-make || {
+if [ ! -z $SLURM_NODELIST ]
+then
+    make_wrapper="srun -n 1"
+fi
+$make_wrapper make || {
     cd -
     exit_with_error_and_venv "make docs failed"
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
+coverage
 flake8
 flake8-print
 pytest
-pytest-cov
 pytest-cython
 restructuredtext-lint
 sphinx

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -14,10 +14,23 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+set -e
+
 pip freeze | grep -qi /brainiak || {
     echo "You must install brainiak in editable mode using \"pip install -e\""`
         `" before calling "$(basename "$0")
     exit 1
 }
 
-py.test --cov=brainiak
+mpi_command=mpiexec
+
+if [ ! -z $SLURM_NODELIST ]
+then
+    mpi_command=srun
+fi
+
+$mpi_command -n 2 coverage run -m pytest
+coverage combine
+coverage report
+coverage html
+coverage xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,13 +1,11 @@
-[pytest]
+[tool:pytest]
 addopts =
-    --junitxml=junit-results.xml
-    --cov-report=xml
-    --cov-report=html
-    --cov-report=term
     --doctest-cython
 
 [coverage:run]
+source = brainiak
 branch = True
+parallel = True
 
 [coverage:report]
 fail_under = 90

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+from mpi4py import MPI
+
+
+def pytest_configure(config):
+    config.option.xmlpath = "junit-{}.xml".format(MPI.COMM_WORLD.Get_rank())


### PR DESCRIPTION
Use `coverage` directly instead of through `pytest-cov`, to be able to
obtain and combine separate reports for MPI processes.

Create separate JUnit XML reports, one for each MPI process.

When running in a Slurm allocation:

* Use `srun` instead of `mpiexec`, given that it is the recommended way to run under Slurm.

* Build the docs through `srun`, because the build process may use MPI.

Fixes #33.