### PR TITLE
Use `setup.cfg` for `flake8` options

### DIFF
--- a/run-checks.sh
+++ b/run-checks.sh
@@ -17,5 +17,5 @@
 set -e
 set -o pipefail
 
-flake8 --ignore=W503 --max-complexity=10 brainiak
+flake8 --config setup.cfg brainiak
 rst-lint *.rst | { grep -v "is clean.$" || true; }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[flake8]
+max-complexity = 10
+
 [tool:pytest]
 addopts =
     --doctest-cython


### PR DESCRIPTION
Ignore all violations ignored by `flake8` by default.

Use `--config` option to make sure `setup.cfg` is the only configuration
file used and other files users might have are ignored.