### PR TITLE
[dev] Install brainiak before dev requirements

### DIFF
--- a/pr-check.sh
+++ b/pr-check.sh
@@ -105,6 +105,10 @@ $activate_venv $venv || {
     exit_with_error "virtualenv activation failed"
 }
 
+# install brainiak in editable mode (required for testing)
+pip3 install $ignore_installed -U -e . || \
+    exit_with_error_and_venv "pip3 failed to install BrainIAK"
+
 # install developer dependencies
 pip3 install $ignore_installed -U -r requirements-dev.txt || \
     exit_with_error_and_venv "pip3 failed to install requirements"
@@ -112,10 +116,6 @@ pip3 install $ignore_installed -U -r requirements-dev.txt || \
 # static analysis
 ./run-checks.sh || \
     exit_with_error_and_venv "run-checks failed"
-
-# install brainiak in editable mode (required for testing)
-pip3 install $ignore_installed -U -e . || \
-    exit_with_error_and_venv "pip3 failed to install BrainIAK"
 
 # run tests
 ./run-tests.sh || \


### PR DESCRIPTION
This makes it easier to detect bugs in dependency management. If an
install dependency is mistakingly added as a development dependency,
`pr-check.sh` will fail.