### PR TITLE
Adding bioRxiv citation

### DIFF
--- a/brainiak/eventseg/event.py
+++ b/brainiak/eventseg/event.py
@@ -19,7 +19,8 @@ learning the signature activity pattern of each event, the model can then be
 applied to other datasets to identify a corresponding sequence of events.
 
 Full details are available in the bioRxiv preprint:
-Christopher Baldassano, Janice Chen, Asieh Zadbood, Jonathan W Pillow, Uri Hasson, Kenneth A Norman
+Christopher Baldassano, Janice Chen, Asieh Zadbood,
+Jonathan W Pillow, Uri Hasson, Kenneth A Norman
 Discovering event structure in continuous narrative perception and memory
 http://biorxiv.org/content/early/2016/10/14/081018
 """

--- a/brainiak/eventseg/event.py
+++ b/brainiak/eventseg/event.py
@@ -17,6 +17,11 @@ Given an ROI timeseries, this class uses an annealed fitting procedure to
 segment the timeseries into events with stable activity patterns. After
 learning the signature activity pattern of each event, the model can then be
 applied to other datasets to identify a corresponding sequence of events.
+
+Full details are available in the bioRxiv preprint:
+Christopher Baldassano, Janice Chen, Asieh Zadbood, Jonathan W Pillow, Uri Hasson, Kenneth A Norman
+Discovering event structure in continuous narrative perception and memory
+http://biorxiv.org/content/early/2016/10/14/081018
 """
 
 # Authors: Chris Baldassano and Cătălin Iordan (Princeton University)


### PR DESCRIPTION
Updating the comment at the top of event.py to reference the bioRxiv preprint describing the event segmentation method.