### PR TITLE
minor bug fixed

### DIFF
--- a/brainiak/fcma/classifier.py
+++ b/brainiak/fcma/classifier.py
@@ -171,6 +171,8 @@ class Classifier(BaseEstimator):
             logger.debug(
                 'normalization done'
             )
+        else:
+            normalized_corr_data = corr_data
         return normalized_corr_data
 
     def _prepare_test_data(self, corr_data):

--- a/brainiak/fcma/classifier.py
+++ b/brainiak/fcma/classifier.py
@@ -151,6 +151,9 @@ class Classifier(BaseEstimator):
         ----------
         corr_data: the correlation data
                     in shape [num_samples, num_voxels, num_voxels]
+        norm_unit: int
+                    the number of samples on which the normalization
+                    is performed
 
         Returns
         -------


### PR DESCRIPTION
a minor caused by renaming `normalized_corr_data` in `_normalize_correlation_data` method. It should return the original `corr_data` if no normalization is performed.