### PR TITLE
[eventseg] Fix binary module name issue

### DIFF
--- a/brainiak/eventseg/event.py
+++ b/brainiak/eventseg/event.py
@@ -33,7 +33,8 @@ import logging
 import copy
 from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_is_fitted, check_array
-import brainiak.eventseg.utils as utils
+
+from . import _utils as utils
 
 logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ ext_modules = [
         ['brainiak/fcma/cython_blas.pyx'],
     ),
     Extension(
-        'brainiak.eventseg.utils',
+        'brainiak.eventseg._utils',
         ['brainiak/eventseg/_utils.pyx'],
     ),
 ]
@@ -99,7 +99,6 @@ class BuildExt(build_ext):
                 ext.extra_compile_args.append(cpp_flag(self.compiler))
                 ext.extra_link_args.append(cpp_flag(self.compiler))
         build_ext.build_extensions(self)
-
 
     def finalize_options(self):
         super().finalize_options()


### PR DESCRIPTION
Python started complaining about `brainiak.eventseg.utils`:
'dynamic module does not define module export function (PyInit_utils)'
https://travis-ci.org/IntelPNI/brainiak/jobs/170847241

Renaming it `brainiak.eventseg._utils`, in accordance to the Cython source file
name, fixes the issue.