### PR TITLE
Fix math and notes

### DIFF
--- a/brainiak/funcalign/srm.py
+++ b/brainiak/funcalign/srm.py
@@ -70,10 +70,13 @@ def _init_w_transforms(data, features):
         A list with the number of voxels per subject.
 
 
-    .. note:: This function assumes that the numpy random number generator was
-       initialized.
+    Note
+    ----
 
-       Not thread safe.
+        This function assumes that the numpy random number generator was
+        initialized.
+
+        Not thread safe.
     """
     w = []
     subjects = len(data)
@@ -95,7 +98,7 @@ class SRM(BaseEstimator, TransformerMixin):
     Given multi-subject data, factorize it as a shared response S among all
     subjects and an orthogonal transform W per subject:
 
-    .. math:: X_i \\approx W_i S ,~for~all~i=1\dots N
+    .. math:: X_i \\approx W_i S, \\exists i=1 \\dots N
 
     Parameters
     ----------
@@ -129,7 +132,9 @@ class SRM(BaseEstimator, TransformerMixin):
         The estimated noise variance :math:`\\rho_i^2` for each subject
 
 
-    .. note::
+    Note
+    ----
+
        The number of voxels may be different between subjects. However, the
        number of samples must be the same across subjects.
 
@@ -428,7 +433,7 @@ class DetSRM(BaseEstimator, TransformerMixin):
     Given multi-subject data, factorize it as a shared response S among all
     subjects and an orthogonal transform W per subject:
 
-    .. math:: X_i \\approx W_i S ,~for~all~i=1\dots N
+    .. math:: X_i \\approx W_i S, \\exists i=1 \\dots N
 
     Parameters
     ----------
@@ -452,20 +457,22 @@ class DetSRM(BaseEstimator, TransformerMixin):
     s_ : array, shape=[features, samples]
         The shared response.
 
-    .. note::
-       The number of voxels may be different between subjects. However, the
-       number of samples must be the same across subjects.
+    Note
+    ----
 
-       The Deterministic Shared Response Model is approximated using the
-       Block Coordinate Descent (BCD) algorithm proposed in [Chen2015]_.
+        The number of voxels may be different between subjects. However, the
+        number of samples must be the same across subjects.
 
-       This is a single node version.
+        The Deterministic Shared Response Model is approximated using the
+        Block Coordinate Descent (BCD) algorithm proposed in [Chen2015]_.
 
-       The run-time complexity is :math:`O(I (V T K + V K^2))` and the memory
-       complexity is :math:`O(V T)` with I - the number of iterations, V - the
-       sum of voxels from all subjects, T - the number of samples, K - the
-       number of features (typically, :math:`V \\gg T \\gg K`), and N - the
-       number of subjects.
+        This is a single node version.
+
+        The run-time complexity is :math:`O(I (V T K + V K^2))` and the memory
+        complexity is :math:`O(V T)` with I - the number of iterations, V - the
+        sum of voxels from all subjects, T - the number of samples, K - the
+        number of features (typically, :math:`V \\gg T \\gg K`), and N - the
+        number of subjects.
     """
 
     def __init__(self, n_iter=10, features=50, rand_seed=0):

--- a/brainiak/funcalign/srm.py
+++ b/brainiak/funcalign/srm.py
@@ -98,7 +98,7 @@ class SRM(BaseEstimator, TransformerMixin):
     Given multi-subject data, factorize it as a shared response S among all
     subjects and an orthogonal transform W per subject:
 
-    .. math:: X_i \\approx W_i S, \\exists i=1 \\dots N
+    .. math:: X_i \\approx W_i S, \\forall i=1 \\dots N
 
     Parameters
     ----------
@@ -433,7 +433,7 @@ class DetSRM(BaseEstimator, TransformerMixin):
     Given multi-subject data, factorize it as a shared response S among all
     subjects and an orthogonal transform W per subject:
 
-    .. math:: X_i \\approx W_i S, \\exists i=1 \\dots N
+    .. math:: X_i \\approx W_i S, \\forall i=1 \\dots N
 
     Parameters
     ----------

--- a/brainiak/funcalign/sssrm.py
+++ b/brainiak/funcalign/sssrm.py
@@ -58,9 +58,11 @@ class SSSRM(BaseEstimator, ClassifierMixin, TransformerMixin):
     data to train a Multinomial Logistic Regression (MLR) classifier (with
     l2 regularization) in a semi-supervised manner:
 
-    .. math:: (1-\alpha) Loss_{SRM}(W_i,S;X_i)
-    .. math:: + \alpha/\gamma  Loss_{MLR}(\theta, bias; {(W_i^T*Z_i, y_i})
-    .. math:: + R(\theta)
+    .. math::
+        (1-\\alpha) Loss_{SRM}(W_i,S;X_i)
+        + \\alpha/\\gamma Loss_{MLR}(\\theta, bias; {(W_i^T \\times Z_i, y_i})
+        + R(\\theta)
+        :label: sssrm-eq
 
     (see Equations (1) and (4) in [Turek2016]_).
 
@@ -101,15 +103,17 @@ class SSSRM(BaseEstimator, ClassifierMixin, TransformerMixin):
     classes_ : array of int, shape=[classes]
         Mapping table for each classes to original class label.
 
-    .. note::
-       The number of voxels may be different between subjects. However, the
-       number of samples for the alignment data must be the same across
-       subjects. The number of labeled samples per subject can be different.
+    Note
+    ----
 
-       The Semi-Supervised Shared Response Model is approximated using the
-       Block-Coordinate Descent (BCD) algorithm proposed in [Turek2016]_.
+        The number of voxels may be different between subjects. However, the
+        number of samples for the alignment data must be the same across
+        subjects. The number of labeled samples per subject can be different.
 
-       This is a single node version.
+        The Semi-Supervised Shared Response Model is approximated using the
+        Block-Coordinate Descent (BCD) algorithm proposed in [Turek2016]_.
+
+        This is a single node version.
     """
 
     def __init__(self, n_iter=10, features=50, gamma=1.0, alpha=0.5,
@@ -207,8 +211,9 @@ class SSSRM(BaseEstimator, ClassifierMixin, TransformerMixin):
         new_y : list of arrays of int, each element has shape=[samples_i,]
             Mapped labels of the samples for each subject
 
-        ..note::
-        The mapping of the classes is saved in the attribute classes_.
+        Note
+        ----
+            The mapping of the classes is saved in the attribute classes_.
         """
         self.classes_ = unique_labels(utils.concatenate_list(y))
         new_y = [None] * len(y)
@@ -572,9 +577,7 @@ class SSSRM(BaseEstimator, ClassifierMixin, TransformerMixin):
                             bias):
         """Compute the objective function of the Semi-Supervised SRM
 
-        .. math:: (1-\alpha)*Loss_{SRM}(W_i,S;X_i)
-        .. math:: + \alpha/\gamma * Loss_{MLR}(\theta, bias; {(W_i^T*Z_i, y_i})
-        .. math:: + R(\theta)
+        See :eq:`sssrm-eq`.
 
         Parameters
         ----------

--- a/brainiak/hyperparamopt/hpo.py
+++ b/brainiak/hyperparamopt/hpo.py
@@ -16,8 +16,8 @@
 This implementation is based on the work:
 
 .. [Bergstra2011] "Algorithms for Hyper-Parameter Optimization",
-   James S. Bergstra and Bardenet, R\'{e}mi and Bengio, Yoshua
-   and Bal\'{a}zs K\'{e}gl. NIPS 2011
+   James S. Bergstra and Bardenet, Rémi and Bengio, Yoshua
+   and Kégl, Balázs. NIPS 2011
 
 .. [Bergstra2013] "Making a Science of Model Search:
    Hyperparameter Optimization in Hundreds of Dimensions for
@@ -122,7 +122,9 @@ class gmm_1d_distribution:
         """Calculate the GMM likelihood for a single point.
 
         .. math::
-            y = \sum_{i=1}^{N} w_i*normpdf(x, x_i, \sigma_i)/\sum_{i=1}^{N} w_i
+            y = \\sum_{i=1}^{N} w_i
+            \\times \\text{normpdf}(x, x_i, \\sigma_i)/\\sum_{i=1}^{N} w_i
+            :label: gmm-likelihood
 
         Arguments
         ---------
@@ -153,8 +155,7 @@ class gmm_1d_distribution:
     def __call__(self, x):
         """Return the GMM likelihood for given point(s).
 
-        .. math::
-            y = \sum_{i=1}^{N} w_i*normpdf(x, x_i, \sigma_i)/\sum_{i=1}^{N} w_i
+        See :eq:`gmm-likelihood`.
 
         Arguments
         ---------

--- a/brainiak/reprsimil/brsa.py
+++ b/brainiak/reprsimil/brsa.py
@@ -62,10 +62,10 @@ class BRSA(BaseEstimator):
     A correlation matrix converted from the covariance matrix
     will be provided as a quantification of neural representational similarity.
 
-    .. math:: \textbf{Y = \textbf{X} \cdot \mbox{\boldmath{$\beta$}}
-        + \mbox{\boldmath{$\eta$}}
-    .. math:: \mbox{\boldmath{$\beta$}}_i \sim \textbf{N}(0,(s_{i}
-        \sigma_{i})^2 \textbf{U})
+    .. math::
+        Y = X \\cdot \\beta + \\epsilon
+
+        \\beta_i \\sim N(0,(s_{i} \\sigma_{i})^2 U)
 
     Parameters
     ----------

--- a/brainiak/utils/utils.py
+++ b/brainiak/utils/utils.py
@@ -129,9 +129,11 @@ def sumexp_stable(data):
         The exponent of each element in each sample divided by the exponent
         of the maximum feature value in the sample.
 
-    ..note::
-    This function is more stable than computing the sum(exp(v)).
-    It useful for computing the softmax_i(v)=exp(v_i)/sum(exp(v)) function.
+    Note
+    ----
+
+        This function is more stable than computing the sum(exp(v)).
+        It useful for computing the softmax_i(v)=exp(v_i)/sum(exp(v)) function.
     """
     max_value = data.max(axis=0)
     result_exp = np.exp(data - max_value)


### PR DESCRIPTION
The most important problem was backslashes that were not escaped.

In the BRSA code, I also changed eta to epsilon to match the paper.

I also replaced a couple of duplicate equations with references.

For notes, the problem was that the `note` directive was mistaken for
another attribute or parameter. It needs to be separated by at least two
blank lines to be recognized as a directive. Instead I replaced it with
a Note section, which looks better in the raw docstring and looks the
same in HTML.

Fixes issue #134.