### PR TITLE
[dev] Workaround for Travis printing error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-#https://travis-ci.org/IntelPNI/brainiak
 branches:
   only:
     - master
@@ -10,49 +9,37 @@ matrix:
       sudo: required
       language: python
       python: 3.4
+      addons: &linux_addons
+        apt: &apt
+          packages:
+            - build-essential libgomp1 libmpich-dev mpich
 
     - os: linux
       dist: trusty
-      sudo: required    
+      sudo: required
       language: python
       python: 3.5
-
-    - os: osx
-      osx_image: xcode7.1
-      sudo: required
-      language: generic
-      env: HINT=Yosemite MPI=mpich
-      before_install:
-          - brew update
-          - brew install python3 
+      addons: *linux_addons
 
     - os: osx
       osx_image: xcode7.3
-      sudo: required
       language: generic
-      env: HINT=ElCapitan MPI=mpich
-      before_install:
-          - brew update
-          - brew install python3 
+      env: &macos_env
+        - CC=/usr/local/opt/llvm/bin/clang
+        - CXX=/usr/local/opt/llvm/bin/clang++
+        - LDFLAGS="-L/usr/local/opt/llvm/lib $LDFLAGS"
+        - CPPFLAGS="-I/usr/local/opt/llvm/include $CPPFLAGS"
+      before_install: &macos_before_install
+        - brew install llvm mpich python3
+
+    - os: osx
+      osx_image: xcode8
+      language: generic
+      env: *macos_env
+      before_install: *macos_before_install
 
 install:
-    - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then sudo apt-get -y install build-essential cmake libgomp1 mpich2 python3-pip; fi   
-
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install llvm mpich; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CC=/usr/local/opt/llvm/bin/clang; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CXX=/usr/local/opt/llvm/bin/clang++; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export LDFLAGS="-L/usr/local/opt/llvm/lib $LDFLAGS"; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export CPPFLAGS="-I/usr/local/opt/llvm/include $CPPFLAGS"; fi
     - pip3 install -U pip virtualenv
 
 script:
-    - ./pr-check.sh pr-check
-
-notifications:
-  webhooks:
-    urls:
-      #- https://webhooks.gitter.im/e/TOSETUP
-    on_success: change  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: never     # options: [always|never|change] default: alwaysfailure: always  # options: [always|never|change] default: always
-    on_start: never     # options: [always|never|change] default: always
+    - ./pr-check.sh

--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,8 @@ Linux
 
 Install the following packages (Ubuntu 14.04 is used in these instructions)::
 
-    apt install build-essential cmake libgomp1 mpich python3-dev python3-pip
+    apt install build-essential libgomp1 libmpich-dev mpich python3-dev \
+        python3-pip
 
 Install updated version of the following Python packages::
 

--- a/pr-check.sh
+++ b/pr-check.sh
@@ -16,7 +16,7 @@
 
 # Check readiness for pull request
 
-set -e
+set -ev
 
 if [ ! -f brainiak/__init__.py ]
 then

--- a/run-checks.sh
+++ b/run-checks.sh
@@ -14,7 +14,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-set -e
+set -ev
 set -o pipefail
 
 flake8 --config setup.cfg brainiak


### PR DESCRIPTION
This error appears intermittently on MacOS with Xcode 7.3:
BlockingIOError: [Errno 35] write could not complete without blocking
https://travis-ci.org/IntelPNI/brainiak/jobs/171502739

I cannot reproduce it outside of Travis. The workaround stops the error
from triggering a build failure. Even with the workaround, the coverage
report is still not fully visible when the error happens.

I also took the opportunity to refactor the Travis configuration. I
added a job using Xcode 8, which will use MacOS 10.12 soon
(this fixes #117):
https://blog.travis-ci.com/2016-10-04-osx-73-default-image-live/

I also made the PR scripts verbose, to make it easier to follow their
progress.

Finally, I added libmpich-dev for mpi.h on Ubuntu.