### PR TITLE
[dev] Declare minimum Python version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -141,5 +141,6 @@ setup(
     cmdclass={'build_ext': BuildExt},
     packages=find_packages(),
     package_data={'brainiak.utils': ['grey_matter_mask.npy']},
+    python_requires='>=3.4',
     zip_safe=False,
 )


### PR DESCRIPTION
In v24.2.0, setuptools introduced support for declaring the minimum
Python version that the package is guaranteed to work with by means
of the `python_requires` keyword:
http://setuptools.readthedocs.io/en/latest/history.html#v24-2-0