### PR TITLE
[docs] Set Sphinx default role to py:obj

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ exclude_patterns = ['_build']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+default_role = 'py:obj'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 #add_function_parentheses = True


### PR DESCRIPTION
This allows creating links for references simply by using backticks
around targets, e.g., `brainiak.fcma.io.write_nifti_file`,
`.fcma.io.read_activity_data`. The dotted notation used by Sphinx is not
the same as relative imports; only one leading dot is allowed; it makes
Sphinx search for the target starting from the current scope outward:
http://www.sphinx-doc.org/en/stable/domains.html#role-py:obj

Note that setting the role to "any" would not allow using the Sphinx
dotted notation.