### PR TITLE
replace pathos.multiprocessing with multiprocess

### DIFF
--- a/brainiak/fcma/voxelselector.py
+++ b/brainiak/fcma/voxelselector.py
@@ -413,10 +413,8 @@ class VoxelSelector:
                        self.labels) for i in range(task[1])]
 
             with multiprocess.Pool(None) as pool:
-                results = list(pool.map(
-                    lambda x: _cross_validation_for_one_voxel
-                    (x[0], x[1], x[2], x[3]),
-                    inlist))
+                results = list(pool.starmap(_cross_validation_for_one_voxel,
+                                            inlist))
         else:
             results = []
             for i in range(task[1]):

--- a/brainiak/fcma/voxelselector.py
+++ b/brainiak/fcma/voxelselector.py
@@ -28,7 +28,7 @@ import sklearn
 from . import fcma_extension
 from . import cython_blas as blas
 import logging
-import pathos.multiprocessing
+import multiprocess
 
 logger = logging.getLogger(__name__)
 
@@ -412,11 +412,11 @@ class VoxelSelector:
             inlist = [(i + task[0], self.num_folds, data[i, :, :],
                        self.labels) for i in range(task[1])]
 
-            pool = pathos.multiprocessing.ProcessingPool(None)
-            results = list(pool.map(
-                lambda x: _cross_validation_for_one_voxel
-                (x[0], x[1], x[2], x[3]),
-                inlist))
+            with multiprocess.Pool(None) as pool:
+                results = list(pool.map(
+                    lambda x: _cross_validation_for_one_voxel
+                    (x[0], x[1], x[2], x[3]),
+                    inlist))
         else:
             results = []
             for i in range(task[1]):


### PR DESCRIPTION
This is to get rid of the dependency of `pathos`. It reported "Too many open files error" before but is fixed by wrapping the usage of `Pool` using `with`.