### PR TITLE
[dev] Use `python3 -m pip` instead of `pip3`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
       before_install: *macos_before_install
 
 install:
-    - pip3 install -U pip virtualenv
+    - python3 -m pip install -U pip virtualenv
 
 script:
     - ./pr-check.sh

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -59,13 +59,13 @@ checks from ``pr-check.sh`` using the steps bellow::
   source ../brainiak_pr_venv/bin/activate
 
   # install developer dependencies
-  pip3 install -U -r requirements-dev.txt
+  python3 -m pip install -U -r requirements-dev.txt
 
   # static analysis
   ./run-checks.sh
 
   # install brainiak in editable mode (required for testing)
-  pip3 install -U -e .
+  python3 -m pip install -U -e .
 
   # run tests
   ./run-tests.sh
@@ -95,7 +95,7 @@ goes wrong.
 The development requirements are listed in ``requirements-dev.txt``. You can
 install them with::
 
-  pip3 install -U -r requirements-dev.txt
+  python3 -m pip install -U -r requirements-dev.txt
 
 
 Standards
@@ -174,8 +174,9 @@ take more than one minute in total on our testing service, `Travis CI`_.
 .. _Travis CI:
   https://travis-ci.org
 
-You must install the package in editable mode using the ``-e`` flag of ``pip3
-install`` before running the tests.
+You must install the package in editable mode before running the tests::
+
+    python3 -m pip install -e .
 
 You can run ``./run-tests.sh`` to run all the unit tests, or you can use the
 ``py.test <your-test-file.py>`` command to run your tests only, at a more

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Install the following packages (Ubuntu 14.04 is used in these instructions)::
 
 Install updated version of the following Python packages::
 
-    pip3 install --user -U pip virtualenv
+    python3 -m pip install --user -U pip virtualenv
 
 Note the ``--user`` flag, which instructs Pip to not overwrite system
 files. You must add ``$HOME/.local/bin`` to your ``$PATH`` to be able to run
@@ -83,7 +83,7 @@ will seek for compiling and linking::
 
 Install updated versions of the following Python packages::
 
-    pip3 install -U pip virtualenv
+    python3 -m pip install -U pip virtualenv
 
 
 Installing
@@ -91,7 +91,7 @@ Installing
 
 The Brain Imaging Analysis Kit is available on PyPI::
 
-    pip3 install -U brainiak
+    python3 -m pip install -U brainiak
 
 Note that you may see a ``Failed building wheel for brainiak`` message (`issue
 #61`_). Installation will proceed despite this failure. You can safely ignore it

--- a/examples/factoranalysis/README.rst
+++ b/examples/factoranalysis/README.rst
@@ -3,6 +3,6 @@ Examples for TFA/HTFA
 
 Install required packages for running get_tfa_input_from_nifti.py::
 
-    pip install -U -r requirements.txt 
+    python3 -m pip install -U -r requirements.txt 
 
 

--- a/pr-check.sh
+++ b/pr-check.sh
@@ -48,9 +48,6 @@ function create_conda_venv {
 
 function activate_conda_venv {
     source activate $1
-    # Anaconda does not provide pip3 (at least on our Jenkins machine,
-    # Metacortex), so we install it in the virtual environment.
-    pip install -I pip
 }
 
 function deactivate_conda_venv {
@@ -108,12 +105,12 @@ $activate_venv $venv || {
 }
 
 # install brainiak in editable mode (required for testing)
-pip3 install $ignore_installed -U -e . || \
-    exit_with_error_and_venv "pip3 failed to install BrainIAK"
+python3 -m pip install $ignore_installed -U -e . || \
+    exit_with_error_and_venv "Failed to install BrainIAK."
 
 # install developer dependencies
-pip3 install $ignore_installed -U -r requirements-dev.txt || \
-    exit_with_error_and_venv "pip3 failed to install requirements"
+python3 -m pip install $ignore_installed -U -r requirements-dev.txt || \
+    exit_with_error_and_venv "Failed to install development requirements."
 
 # static analysis
 ./run-checks.sh || \

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -16,8 +16,8 @@
 
 set -e
 
-pip freeze | grep -qi /brainiak || {
-    echo "You must install brainiak in editable mode using \"pip install -e\""`
+python3 -m pip freeze | grep -qi /brainiak || {
+    echo "You must install brainiak in editable mode"`
         `" before calling "$(basename "$0")
     exit 1
 }


### PR DESCRIPTION
Reduces problems when working with multiple versions of Python. See:
https://docs.python.org/3/installing/#work-with-multiple-versions-of-python-installed-in-parallel
http://bugs.python.org/issue22295

Fixes #79.