### PR TITLE
[dev] Switch from `virtualenv` to `venv`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
       before_install: *macos_before_install
 
 install:
-    - python3 -m pip install -U pip virtualenv
+    - python3 -m pip install -U pip
 
 script:
     - ./pr-check.sh

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -51,11 +51,11 @@ the virtual environment to be set up every time. You can run the individual
 checks from ``pr-check.sh`` using the steps bellow::
 
   # do not run this if using Anaconda, because Anaconda is not compatible with
-  # virtualenv; instead, look at pr-check.sh to see how to run the individual
+  # venv; instead, look at pr-check.sh to see how to run the individual
   # checks that are part of pr-check.sh using Anaconda
 
-  # optional, but highly recommended: create a virtualenv to isolate tests
-  virtualenv ../brainiak_pr_venv
+  # optional, but highly recommended: create a virtual environment
+  python3 -m venv ../brainiak_pr_venv
   source ../brainiak_pr_venv/bin/activate
 
   # install developer dependencies
@@ -75,7 +75,7 @@ checks from ``pr-check.sh`` using the steps bellow::
   make
   cd -
 
-  # optional: remove virtualenv, if you created one
+  # optional: remove the virtual environment, if you created one
   deactivate
   rm -r ../brainiak_pr_venv
 

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Install the following packages (Ubuntu 14.04 is used in these instructions)::
 
 Install updated version of the following Python packages::
 
-    python3 -m pip install --user -U pip virtualenv
+    python3 -m pip install --user -U pip
 
 Note the ``--user`` flag, which instructs Pip to not overwrite system
 files. You must add ``$HOME/.local/bin`` to your ``$PATH`` to be able to run
@@ -83,7 +83,7 @@ will seek for compiling and linking::
 
 Install updated versions of the following Python packages::
 
-    python3 -m pip install -U pip virtualenv
+    python3 -m pip install -U pip
 
 
 Installing

--- a/pr-check.sh
+++ b/pr-check.sh
@@ -26,19 +26,19 @@ fi
 
 basedir=$(pwd)
 
-function create_virtualenv_venv {
-    virtualenv ../$1
+function create_venv_venv {
+    python3 -m venv ../$1
 }
 
-function activate_virtualenv_venv {
+function activate_venv_venv {
     source ../$1/bin/activate
 }
 
-function deactivate_virtualenv_venv {
+function deactivate_venv_venv {
     deactivate
 }
 
-function remove_virtualenv_venv {
+function remove_venv_venv {
     rm -r ../$1
 }
 
@@ -79,29 +79,23 @@ then
     deactivate_venv=deactivate_conda_venv
     remove_venv=remove_conda_venv
     ignore_installed="--ignore-installed"
-elif [ $(which virtualenv) ]
-then
-    create_venv=create_virtualenv_venv
-    activate_venv=activate_virtualenv_venv
-    deactivate_venv=deactivate_virtualenv_venv
-    remove_venv=remove_virtualenv_venv
 else
-    echo "Cannot find virtualenv or conda."
-    echo "You must install one of them or test manually."
-    exit 1
+    create_venv=create_venv_venv
+    activate_venv=activate_venv_venv
+    deactivate_venv=deactivate_venv_venv
+    remove_venv=remove_venv_venv
 fi
 
 git clean -Xf .
 
-# optional, but highly recommended: create a virtualenv to isolate tests
 venv=$(mktemp -u brainiak_pr_venv_XXXXX) || \
     exit_with_error "mktemp -u error"
 $create_venv $venv || {
-    exit_with_error "virtualenv creation failed"
+    exit_with_error "Virtual environment creation failed."
 }
 $activate_venv $venv || {
     $remove_venv $venv
-    exit_with_error "virtualenv activation failed"
+    exit_with_error "Virtual environment activation failed."
 }
 
 # install brainiak in editable mode (required for testing)
@@ -134,7 +128,6 @@ $make_wrapper make || {
 }
 cd -
 
-# optional: remove virtualenv
 $deactivate_venv
 $remove_venv $venv
 


### PR DESCRIPTION
`venv` is part of the Python standard library.

Fixes #78.