### PR TITLE
SRM: Use per-subject random number generators

### DIFF
--- a/brainiak/funcalign/srm.py
+++ b/brainiak/funcalign/srm.py
@@ -47,7 +47,7 @@ __all__ = [
 logger = logging.getLogger(__name__)
 
 
-def _init_w_transforms(data, features):
+def _init_w_transforms(data, features, random_states):
     """Initialize the mappings (Wi) for the SRM with random orthogonal matrices.
 
     Parameters
@@ -58,6 +58,9 @@ def _init_w_transforms(data, features):
 
     features : int
         The number of features in the model.
+
+    random_states : list of `RandomState`s
+        One `RandomState` instance per subject.
 
 
     Returns
@@ -86,7 +89,8 @@ def _init_w_transforms(data, features):
     # Set Wi to a random orthogonal voxels by features matrix
     for subject in range(subjects):
         voxels[subject] = data[subject].shape[0]
-        rnd_matrix = np.random.random((voxels[subject], features))
+        rnd_matrix = random_states[subject].random_sample((voxels[subject],
+                                                           features))
         q, r = np.linalg.qr(rnd_matrix)
         w.append(q)
 
@@ -131,6 +135,9 @@ class SRM(BaseEstimator, TransformerMixin):
 
     rho2_ : array, shape=[subjects]
         The estimated noise variance :math:`\\rho_i^2` for each subject
+
+    random_state_: `RandomState`
+        Random number generator initialized using rand_seed
 
 
     Note
@@ -346,12 +353,14 @@ class SRM(BaseEstimator, TransformerMixin):
         samples = data[0].shape[1]
         subjects = len(data)
 
-        np.random.seed(self.rand_seed)
+        self.random_state_ = np.random.RandomState(self.rand_seed)
+        random_states = [np.random.RandomState(self.random_state_.randint())
+                         for i in range(len(data))]
 
         # Initialization step: initialize the outputs with initial values,
         # voxels with the number of voxels in each subject, and trace_xtx with
         # the ||X_i||_F^2 of each subject.
-        w, voxels = _init_w_transforms(data, self.features)
+        w, voxels = _init_w_transforms(data, self.features, random_states)
         x, mu, rho2, trace_xtx = self._init_structures(data, subjects)
         shared_response = np.zeros((self.features, samples))
         sigma_s = np.identity(self.features)
@@ -457,6 +466,9 @@ class DetSRM(BaseEstimator, TransformerMixin):
 
     s_ : array, shape=[features, samples]
         The shared response.
+
+    random_state_: `RandomState`
+        Random number generator initialized using rand_seed
 
     Note
     ----
@@ -627,11 +639,13 @@ class DetSRM(BaseEstimator, TransformerMixin):
 
         subjects = len(data)
 
-        np.random.seed(self.rand_seed)
+        self.random_state_ = np.random.RandomState(self.rand_seed)
+        random_states = [np.random.RandomState(self.random_state_.randint())
+                         for i in range(len(data))]
 
         # Initialization step: initialize the outputs with initial values,
         # voxels with the number of voxels in each subject.
-        w, _ = _init_w_transforms(data, self.features)
+        w, _ = _init_w_transforms(data, self.features, random_states)
         shared_response = self._compute_shared_response(data, w)
         if logger.isEnabledFor(logging.INFO):
             # Calculate the current objective function value

--- a/brainiak/funcalign/srm.py
+++ b/brainiak/funcalign/srm.py
@@ -354,7 +354,7 @@ class SRM(BaseEstimator, TransformerMixin):
         subjects = len(data)
 
         self.random_state_ = np.random.RandomState(self.rand_seed)
-        random_states = [np.random.RandomState(self.random_state_.randint())
+        random_states = [np.random.RandomState(self.random_state_.randint(0))
                          for i in range(len(data))]
 
         # Initialization step: initialize the outputs with initial values,
@@ -640,7 +640,7 @@ class DetSRM(BaseEstimator, TransformerMixin):
         subjects = len(data)
 
         self.random_state_ = np.random.RandomState(self.rand_seed)
-        random_states = [np.random.RandomState(self.random_state_.randint())
+        random_states = [np.random.RandomState(self.random_state_.randint(0))
                          for i in range(len(data))]
 
         # Initialization step: initialize the outputs with initial values,

--- a/brainiak/funcalign/srm.py
+++ b/brainiak/funcalign/srm.py
@@ -354,8 +354,9 @@ class SRM(BaseEstimator, TransformerMixin):
         subjects = len(data)
 
         self.random_state_ = np.random.RandomState(self.rand_seed)
-        random_states = [np.random.RandomState(self.random_state_.randint(0))
-                         for i in range(len(data))]
+        random_states = [
+            np.random.RandomState(self.random_state_.randint(2**32))
+            for i in range(len(data))]
 
         # Initialization step: initialize the outputs with initial values,
         # voxels with the number of voxels in each subject, and trace_xtx with
@@ -640,8 +641,9 @@ class DetSRM(BaseEstimator, TransformerMixin):
         subjects = len(data)
 
         self.random_state_ = np.random.RandomState(self.rand_seed)
-        random_states = [np.random.RandomState(self.random_state_.randint(0))
-                         for i in range(len(data))]
+        random_states = [
+            np.random.RandomState(self.random_state_.randint(2**32))
+            for i in range(len(data))]
 
         # Initialization step: initialize the outputs with initial values,
         # voxels with the number of voxels in each subject.

--- a/brainiak/funcalign/sssrm.py
+++ b/brainiak/funcalign/sssrm.py
@@ -103,6 +103,9 @@ class SSSRM(BaseEstimator, ClassifierMixin, TransformerMixin):
     classes_ : array of int, shape=[classes]
         Mapping table for each classes to original class label.
 
+    random_state_: `RandomState`
+        Random number generator initialized using rand_seed
+
     Note
     ----
 
@@ -322,9 +325,11 @@ class SSSRM(BaseEstimator, ClassifierMixin, TransformerMixin):
         classes = self.classes_.size
 
         # Initialization:
-        np.random.seed(self.rand_seed)
+        self.random_state_ = np.random.RandomState(self.rand_seed)
+        random_states = [np.random.RandomState(self.random_state_.randint())
+                         for i in range(len(data_align))]
         # Set Wi's to a random orthogonal voxels by TRs
-        w, _ = srm._init_w_transforms(data_align, self.features)
+        w, _ = srm._init_w_transforms(data_align, self.features, random_states)
 
         # Initialize the shared response S
         s = SSSRM._compute_shared_response(data_align, w)

--- a/brainiak/funcalign/sssrm.py
+++ b/brainiak/funcalign/sssrm.py
@@ -326,7 +326,7 @@ class SSSRM(BaseEstimator, ClassifierMixin, TransformerMixin):
 
         # Initialization:
         self.random_state_ = np.random.RandomState(self.rand_seed)
-        random_states = [np.random.RandomState(self.random_state_.randint())
+        random_states = [np.random.RandomState(self.random_state_.randint(0))
                          for i in range(len(data_align))]
         # Set Wi's to a random orthogonal voxels by TRs
         w, _ = srm._init_w_transforms(data_align, self.features, random_states)

--- a/brainiak/funcalign/sssrm.py
+++ b/brainiak/funcalign/sssrm.py
@@ -326,8 +326,9 @@ class SSSRM(BaseEstimator, ClassifierMixin, TransformerMixin):
 
         # Initialization:
         self.random_state_ = np.random.RandomState(self.rand_seed)
-        random_states = [np.random.RandomState(self.random_state_.randint(0))
-                         for i in range(len(data_align))]
+        random_states = [
+            np.random.RandomState(self.random_state_.randint(2**32))
+            for i in range(len(data_align))]
         # Set Wi's to a random orthogonal voxels by TRs
         w, _ = srm._init_w_transforms(data_align, self.features, random_states)
 


### PR DESCRIPTION
Enables checking the upcoming distributed implementation.

Also, fixes a part of #112.