### PR TITLE
dev: Remove MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include LICENSE


### PR DESCRIPTION
The only file we list, LICENSE, is included in the sdist regardless of
MANIFEST.in, thanks to setuptools_scm. Furthermore, bdist_wheel ignores
MANIFEST.in:
https://packaging.python.org/tutorials/distributing-packages/#manifest-in

Fixes #90.