### PR TITLE
dev: Run flake8 on test code

### DIFF
--- a/run-checks.sh
+++ b/run-checks.sh
@@ -18,8 +18,9 @@ set -e
 set -o pipefail
 
 flake8 --config setup.cfg brainiak
+flake8 --config tests/.flake8 tests
 mypy --ignore-missing-imports brainiak tests/[!_]*
-rst-lint *.rst | { grep -v "is clean.$" || true; }
+rst-lint ./*.rst | { grep -v "is clean.$" || true; }
 towncrier --version=100 --draft > /dev/null 2>&1 \
     || echo "Error assembling news fragments using towncrier."
 

--- a/tests/.flake8
+++ b/tests/.flake8
@@ -11,11 +11,5 @@ ignore =
     E704,
     W503,
     W504,
-
-[coverage:run]
-source = brainiak
-branch = True
-parallel = True
-
-[coverage:report]
-fail_under = 90
+    # Print restriction only applies to libraries
+    T003

--- a/tests/eventseg/test_event.py
+++ b/tests/eventseg/test_event.py
@@ -1,6 +1,7 @@
 import brainiak.eventseg.event
 import numpy as np
 
+
 def test_create_event_segmentation():
     es = brainiak.eventseg.event.EventSegment(5)
     assert es, "Invalid EventSegment instance"
@@ -14,8 +15,8 @@ def test_fit_shapes():
     sample_data = np.random.rand(V, T)
     es.fit(sample_data.T)
 
-    assert es.segments_[0].shape == (T,K), "Segmentation from fit " \
-                                           "has incorrect shape"
+    assert es.segments_[0].shape == (T, K), "Segmentation from fit " \
+                                            "has incorrect shape"
     assert np.isclose(np.sum(es.segments_[0], axis=1), np.ones(T)).all(), \
         "Segmentation from learn_events not correctly normalized"
 
@@ -27,6 +28,7 @@ def test_fit_shapes():
                                            "has incorrect shape"
     assert np.isclose(np.sum(test_segments, axis=1), np.ones(T2)).all(), \
         "Segmentation from find_events not correctly normalized"
+
 
 def test_simple_boundary():
     es = brainiak.eventseg.event.EventSegment(2, n_iter=10)

--- a/tests/factoranalysis/test_htfa.py
+++ b/tests/factoranalysis/test_htfa.py
@@ -13,11 +13,13 @@
 #  limitations under the License.
 import pytest
 
+
 def test_R():
     from brainiak.factoranalysis.htfa import HTFA
     with pytest.raises(TypeError) as excinfo:
-        htfa = HTFA()
+        HTFA()
     assert "missing 1 required positional argument" in str(excinfo.value)
+
 
 def test_X():
     from brainiak.factoranalysis.htfa import HTFA
@@ -84,14 +86,16 @@ def test_X():
     # Check that does NOT run with wrong data type
     with pytest.raises(TypeError) as excinfo:
         htfa.fit(X, R=R)
-    assert "Each scanner coordinate matrix should be an array" in str(excinfo.value)
+    assert ("Each scanner coordinate matrix should be an array"
+            in str(excinfo.value))
 
     R = []
     R.append(np.random.rand(n_voxel))
     # Check that does NOT run with wrong array dimension
     with pytest.raises(TypeError) as excinfo:
         htfa.fit(X, R=R)
-    assert "Each scanner coordinate matrix should be 2D array" in str(excinfo.value)
+    assert ("Each scanner coordinate matrix should be 2D array"
+            in str(excinfo.value))
 
     R = []
     for s in np.arange(n_subj):
@@ -99,7 +103,8 @@ def test_X():
     # Check that does NOT run with wrong array dimension
     with pytest.raises(TypeError) as excinfo:
         htfa.fit(X, R=R)
-    assert "n_voxel should be the same in X[idx] and R[idx]" in str(excinfo.value)
+    assert ("n_voxel should be the same in X[idx] and R[idx]"
+            in str(excinfo.value))
 
 
 def test_can_run():

--- a/tests/factoranalysis/test_tfa.py
+++ b/tests/factoranalysis/test_tfa.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 import pytest
 
+
 def test_tfa():
     from brainiak.factoranalysis.tfa import TFA
     import numpy as np
@@ -23,7 +24,6 @@ def test_tfa():
     max_iter = 5
     max_num_voxel = n_voxel
     max_num_tr = n_tr
-    sample_scaling = 0.5
     tfa = TFA(
         K=K,
         max_iter=max_iter,
@@ -108,5 +108,3 @@ def test_tfa():
         tfa.fit(X, R=R)
     assert "'rr' and 'ols' are accepted as weight_method!" in str(
         excinfo.value)
-
-

--- a/tests/fcma/test_classification.py
+++ b/tests/fcma/test_classification.py
@@ -24,6 +24,7 @@ from scipy.spatial.distance import hamming
 # specify the random state to fix the random numbers
 prng = RandomState(1234567890)
 
+
 def create_epoch(idx, num_voxels):
     row = 12
     col = num_voxels
@@ -38,6 +39,7 @@ def create_epoch(idx, num_voxels):
     mat = mat / math.sqrt(mat.shape[0])
     return mat
 
+
 def test_classification():
     fake_raw_data = [create_epoch(i, 5) for i in range(20)]
     labels = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
@@ -48,14 +50,14 @@ def test_classification():
     training_data = fake_raw_data[0:12]
     clf = Classifier(svm_clf, epochs_per_subj=epochs_per_subj)
     clf.fit(list(zip(training_data, training_data)), labels[0:12])
-    expected_confidence = np.array([-1.18234421, 0.97403604, -1.04005679, 
+    expected_confidence = np.array([-1.18234421, 0.97403604, -1.04005679,
                                     0.92403019, -0.95567738, 1.11746593,
                                     -0.83275891, 0.9486868])
-    recomputed_confidence = clf.decision_function(list(zip(fake_raw_data[12:],
-                                                           fake_raw_data[12:])))
+    recomputed_confidence = clf.decision_function(list(zip(
+        fake_raw_data[12:], fake_raw_data[12:])))
     hamming_distance = hamming(np.sign(expected_confidence),
-                               np.sign(recomputed_confidence)) \
-                       * expected_confidence.size
+                               np.sign(recomputed_confidence)
+                               ) * expected_confidence.size
     assert hamming_distance <= 1, \
         'decision function of SVM with recomputation ' \
         'does not provide correct results'
@@ -67,7 +69,8 @@ def test_classification():
     confidence = clf.decision_function(list(zip(fake_raw_data[12:],
                                                 fake_raw_data[12:])))
     hamming_distance = hamming(np.sign(expected_confidence),
-			       np.sign(confidence)) * confidence.size
+                               np.sign(confidence)
+                               ) * confidence.size
     assert hamming_distance <= 1, \
         'decision function of SVM without recomputation ' \
         'does not provide correct results'
@@ -78,7 +81,9 @@ def test_classification():
     # svm with partial similarity matrix computation
     clf = Classifier(svm_clf, num_processed_voxels=2,
                      epochs_per_subj=epochs_per_subj)
-    clf.fit(list(zip(fake_raw_data, fake_raw_data)), labels, num_training_samples=12)
+    clf.fit(list(zip(fake_raw_data, fake_raw_data)),
+            labels,
+            num_training_samples=12)
     y_pred = clf.predict()
     expected_output = [0, 0, 0, 1, 0, 1, 0, 1]
     hamming_distance = hamming(y_pred, expected_output) * len(y_pred)
@@ -95,12 +100,14 @@ def test_classification():
     lr_clf = LogisticRegression()
     clf = Classifier(lr_clf, epochs_per_subj=epochs_per_subj)
     clf.fit(list(zip(training_data, training_data)), labels[0:12])
-    expected_confidence = np.array([-4.49666484, 3.73025553, -4.04181695, 
+    expected_confidence = np.array([-4.49666484, 3.73025553, -4.04181695,
                                     3.73027436, -3.77043872, 4.42613412,
                                     -3.35616616, 3.77716609])
-    recomputed_confidence = clf.decision_function(list(zip(fake_raw_data[12:], fake_raw_data[12:])))
-    hamming_distance = hamming(np.sign(expected_confidence), 
-			       np.sign(recomputed_confidence)) * expected_confidence.size
+    recomputed_confidence = clf.decision_function(list(zip(
+        fake_raw_data[12:], fake_raw_data[12:])))
+    hamming_distance = hamming(np.sign(expected_confidence),
+                               np.sign(recomputed_confidence)
+                               ) * expected_confidence.size
     assert hamming_distance <= 1, \
         'decision function of logistic regression with recomputation ' \
         'does not provide correct results'
@@ -110,12 +117,15 @@ def test_classification():
     assert hamming_distance <= 1, \
         'classification via logistic regression ' \
         'does not provide correct results'
-    confidence = clf.decision_function(list(zip(fake_raw_data[12:], fake_raw_data[12:])))
+    confidence = clf.decision_function(list(zip(
+        fake_raw_data[12:], fake_raw_data[12:])))
     hamming_distance = hamming(np.sign(expected_confidence),
-			       np.sign(confidence)) * confidence.size
+                               np.sign(confidence)
+                               ) * confidence.size
     assert hamming_distance <= 1, \
         'decision function of logistic regression without precomputation ' \
         'does not provide correct results'
+
 
 def test_classification_with_two_components():
     fake_raw_data = [create_epoch(i, 5) for i in range(20)]
@@ -132,11 +142,11 @@ def test_classification_with_two_components():
     expected_confidence = np.array([-1.23311606, 1.02440964, -0.93898336,
                                     1.07028798, -1.04420007, 0.97647772,
                                     -1.0498268, 1.04970111])
-    recomputed_confidence = clf.decision_function(list(zip(fake_raw_data[12:],
-                                                           fake_raw_data2[12:])))
+    recomputed_confidence = clf.decision_function(list(zip(
+        fake_raw_data[12:], fake_raw_data2[12:])))
     hamming_distance = hamming(np.sign(expected_confidence),
-                               np.sign(recomputed_confidence)) \
-                       * expected_confidence.size
+                               np.sign(recomputed_confidence)
+                               ) * expected_confidence.size
     assert hamming_distance <= 1, \
         'decision function of SVM with recomputation ' \
         'does not provide correct results'
@@ -145,7 +155,8 @@ def test_classification_with_two_components():
     hamming_distance = hamming(y_pred, expected_output) * len(y_pred)
     assert hamming_distance <= 1, \
         'classification via SVM does not provide correct results'
-    confidence = clf.decision_function(list(zip(fake_raw_data[12:], fake_raw_data2[12:])))
+    confidence = clf.decision_function(list(zip(
+        fake_raw_data[12:], fake_raw_data2[12:])))
     hamming_distance = hamming(np.sign(expected_confidence),
                                np.sign(confidence)) * confidence.size
     assert hamming_distance <= 1, \
@@ -158,7 +169,9 @@ def test_classification_with_two_components():
     # svm with partial similarity matrix computation
     clf = Classifier(svm_clf, num_processed_voxels=2,
                      epochs_per_subj=epochs_per_subj)
-    clf.fit(list(zip(fake_raw_data, fake_raw_data2)), labels, num_training_samples=12)
+    clf.fit(list(zip(fake_raw_data, fake_raw_data2)),
+            labels,
+            num_training_samples=12)
     y_pred = clf.predict()
     expected_output = [0, 1, 0, 1, 0, 1, 0, 1]
     hamming_distance = hamming(y_pred, expected_output) * len(y_pred)
@@ -175,14 +188,17 @@ def test_classification_with_two_components():
     lr_clf = LogisticRegression()
     clf = Classifier(lr_clf, epochs_per_subj=epochs_per_subj)
     # specifying num_training_samples is for coverage
-    clf.fit(list(zip(training_data, training_data2)), labels[0:12], num_training_samples=12)
+    clf.fit(list(zip(training_data, training_data2)),
+            labels[0:12],
+            num_training_samples=12)
     expected_confidence = np.array([-4.90819848, 4.22548132, -3.76255726,
                                     4.46505975, -4.19933099, 4.08313584,
                                     -4.23070437, 4.31779758])
-    recomputed_confidence = clf.decision_function(list(zip(fake_raw_data[12:],
-                                                           fake_raw_data2[12:])))
+    recomputed_confidence = clf.decision_function(list(zip(
+        fake_raw_data[12:], fake_raw_data2[12:])))
     hamming_distance = hamming(np.sign(expected_confidence),
-                               np.sign(recomputed_confidence)) * expected_confidence.size
+                               np.sign(recomputed_confidence)
+                               ) * expected_confidence.size
     assert hamming_distance <= 1, \
         'decision function of logistic regression with recomputation ' \
         'does not provide correct results'
@@ -199,6 +215,7 @@ def test_classification_with_two_components():
     assert hamming_distance <= 1, \
         'decision function of logistic regression without precomputation ' \
         'does not provide correct results'
+
 
 if __name__ == '__main__':
     test_classification()

--- a/tests/fcma/test_mvpa_voxel_selection.py
+++ b/tests/fcma/test_mvpa_voxel_selection.py
@@ -22,6 +22,7 @@ from numpy.random import RandomState
 # specify the random state to fix the random numbers
 prng = RandomState(1234567890)
 
+
 def test_mvpa_voxel_selection():
     data = prng.rand(5, 5, 5, 8).astype(np.float32)
     # all MPI processes read the mask; the mask file is small
@@ -44,6 +45,7 @@ def test_mvpa_voxel_selection():
                            4, 4, 4, 3, 3, 3, 3, 3, 2, 2, 2, 1]
         assert np.allclose(output, expected_output, atol=1), \
             'voxel selection via SVM does not provide correct results'
+
 
 if __name__ == '__main__':
     test_mvpa_voxel_selection()

--- a/tests/fcma/test_preprocessing.py
+++ b/tests/fcma/test_preprocessing.py
@@ -44,16 +44,15 @@ def test_prepare_fcma_data():
     from brainiak.fcma.preprocessing import RandomType
     images = io.load_images_from_dir(data_dir, suffix=suffix)
     random_raw_data, _, _ = prepare_fcma_data(images, conditions, mask,
-                                                   random=
-                                                   RandomType.REPRODUCIBLE)
+                                              random=RandomType.REPRODUCIBLE)
     assert len(random_raw_data) == len(expected_raw_data), \
         'numbers of epochs do not match in test_prepare_fcma_data'
     images = io.load_images_from_dir(data_dir, suffix=suffix)
     random_raw_data, _, _ = prepare_fcma_data(images, conditions, mask,
-                                                   random=
-                                                   RandomType.UNREPRODUCIBLE)
+                                              random=RandomType.UNREPRODUCIBLE)
     assert len(random_raw_data) == len(expected_raw_data), \
         'numbers of epochs do not match in test_prepare_fcma_data'
+
 
 def test_prepare_mvpa_data():
     images = io.load_images_from_dir(data_dir, suffix=suffix)
@@ -65,10 +64,12 @@ def test_prepare_mvpa_data():
     assert len(processed_data) == len(expected_processed_data), \
         'numbers of epochs do not match in test_prepare_mvpa_data'
     for idx in range(len(processed_data)):
-        assert np.allclose(processed_data[idx], expected_processed_data[idx]), \
-            'raw data do not match in test_prepare_mvpa_data'
+        assert np.allclose(processed_data[idx],
+                           expected_processed_data[idx]), (
+            'raw data do not match in test_prepare_mvpa_data')
     assert np.array_equal(labels, expected_labels), \
         'the labels do not match in test_prepare_mvpa_data'
+
 
 def test_prepare_searchlight_mvpa_data():
     images = io.load_images_from_dir(data_dir, suffix=suffix)
@@ -78,25 +79,29 @@ def test_prepare_searchlight_mvpa_data():
     expected_searchlight_processed_data = np.load(
         expected_dir / 'expected_searchlight_processed_data.npy')
     for idx in range(len(processed_data)):
-        assert np.allclose(processed_data[idx], expected_searchlight_processed_data[idx]), \
-            'raw data do not match in test_prepare_searchlight_mvpa_data'
+        assert np.allclose(processed_data[idx],
+                           expected_searchlight_processed_data[idx]), (
+            'raw data do not match in test_prepare_searchlight_mvpa_data')
     assert np.array_equal(labels, expected_labels), \
         'the labels do not match in test_prepare_searchlight_mvpa_data'
     from brainiak.fcma.preprocessing import RandomType
     images = io.load_images_from_dir(data_dir, suffix=suffix)
-    random_processed_data, _ = prepare_searchlight_mvpa_data(images,
-                                                             conditions,
-                                                             random=
-                                                             RandomType.REPRODUCIBLE)
-    assert len(random_processed_data) == len(expected_searchlight_processed_data), \
-        'numbers of epochs do not match in test_prepare_searchlight_mvpa_data'
+    random_processed_data, _ = prepare_searchlight_mvpa_data(
+        images,
+        conditions,
+        random=RandomType.REPRODUCIBLE)
+    assert (len(random_processed_data)
+            == len(expected_searchlight_processed_data)), (
+        'numbers of epochs do not match in test_prepare_searchlight_mvpa_data')
     images = io.load_images_from_dir(data_dir, suffix=suffix)
-    random_processed_data, _ = prepare_searchlight_mvpa_data(images,
-                                                             conditions,
-                                                             random=
-                                                             RandomType.UNREPRODUCIBLE)
-    assert len(random_processed_data) == len(expected_searchlight_processed_data), \
-        'numbers of epochs do not match in test_prepare_searchlight_mvpa_data'
+    random_processed_data, _ = prepare_searchlight_mvpa_data(
+        images,
+        conditions,
+        random=RandomType.UNREPRODUCIBLE)
+    assert (len(random_processed_data)
+            == len(expected_searchlight_processed_data)), (
+        'numbers of epochs do not match in test_prepare_searchlight_mvpa_data')
+
 
 if __name__ == '__main__':
     test_prepare_fcma_data()

--- a/tests/fcma/test_util.py
+++ b/tests/fcma/test_util.py
@@ -19,6 +19,7 @@ from brainiak.fcma.util import compute_correlation
 # specify the random state to fix the random numbers
 prng = RandomState(1234567890)
 
+
 def test_correlation_computation():
     row1 = 5
     col = 10
@@ -27,13 +28,16 @@ def test_correlation_computation():
     mat2 = prng.rand(row2, col).astype(np.float32)
     corr = compute_correlation(mat1, mat1)
     expected_corr = np.corrcoef(mat1)
-    assert np.allclose(corr, expected_corr, atol=1e-5), \
-        'high performance correlation computation does not provide correct correlation results within the same set'
+    assert np.allclose(corr, expected_corr, atol=1e-5), (
+        "high performance correlation computation does not provide correct "
+        "correlation results within the same set")
     corr = compute_correlation(mat1, mat2)
     mat = np.concatenate((mat1, mat2), axis=0)
     expected_corr = np.corrcoef(mat)[0:row1, row1:]
-    assert np.allclose(corr, expected_corr, atol=1e-5), \
-        'high performance correlation computation does not provide correct correlation results between two sets'
+    assert np.allclose(corr, expected_corr, atol=1e-5), (
+        "high performance correlation computation does not provide correct "
+        "correlation results between two sets")
+
 
 if __name__ == '__main__':
     test_correlation_computation()

--- a/tests/fcma/test_voxel_selection.py
+++ b/tests/fcma/test_voxel_selection.py
@@ -24,6 +24,7 @@ from numpy.random import RandomState
 # specify the random state to fix the random numbers
 prng = RandomState(1234567890)
 
+
 def create_epoch():
     row = 12
     col = 5
@@ -34,6 +35,7 @@ def create_epoch():
     mat = np.nan_to_num(mat)
     mat = mat / math.sqrt(mat.shape[0])
     return mat
+
 
 def test_voxel_selection():
     fake_raw_data = [create_epoch() for i in range(8)]
@@ -73,8 +75,10 @@ def test_voxel_selection():
         for tuple in results:
             output[tuple[0]] = int(8*tuple[1])
         expected_output = [6, 3, 6, 4, 4]
-        assert np.allclose(output, expected_output, atol=1), \
-            'voxel selection via logistic regression does not provide correct results'
+        assert np.allclose(output, expected_output, atol=1), (
+            "voxel selection via logistic regression does not provide correct "
+            "results")
+
 
 def test_voxel_selection_with_two_masks():
     fake_raw_data1 = [create_epoch() for i in range(8)]
@@ -102,8 +106,10 @@ def test_voxel_selection_with_two_masks():
         for tuple in results:
             output[tuple[0]] = int(8*tuple[1])
         expected_output = [3, 4, 4, 6, 6]
-        assert np.allclose(output, expected_output, atol=1), \
-            'voxel selection via logistic regression does not provide correct results'
+        assert np.allclose(output, expected_output, atol=1), (
+            "voxel selection via logistic regression does not provide correct "
+            "results")
+
 
 if __name__ == '__main__':
     test_voxel_selection()

--- a/tests/funcalign/test_srm.py
+++ b/tests/funcalign/test_srm.py
@@ -14,6 +14,7 @@
 from sklearn.exceptions import NotFittedError
 import pytest
 
+
 def test_can_instantiate():
     import brainiak.funcalign.srm
     s = brainiak.funcalign.srm.SRM()
@@ -29,7 +30,6 @@ def test_can_instantiate():
 
     s = brainiak.funcalign.srm.SRM(n_iter=5, features=features)
     assert s, "Invalid SRM instance!"
-
 
     # Create a Shared response S with K = 3
     theta = np.linspace(-4 * np.pi, 4 * np.pi, samples)
@@ -47,12 +47,12 @@ def test_can_instantiate():
     X.append(Q.dot(S) + 0.1*np.random.random((voxels, samples)))
 
     # Check that transform does NOT run before fitting the model
-    with pytest.raises(NotFittedError) as excinfo:
+    with pytest.raises(NotFittedError):
         s.transform(X)
     print("Test: transforming before fitting the model")
 
     # Check that it does NOT run with 1 subject
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         s.fit(X)
     print("Test: running SRM with 1 subject")
 
@@ -67,44 +67,55 @@ def test_can_instantiate():
     sr_v0_4 = np.load(Path(__file__).parent / "sr_v0_4.npz")['sr']
     assert(np.allclose(sr_v0_4, s.s_))
 
-    assert len(s.w_) == subjects, "Invalid computation of SRM! (wrong # subjects in W)"
+    assert len(s.w_) == subjects, (
+        "Invalid computation of SRM! (wrong # subjects in W)")
     for subject in range(subjects):
-        assert s.w_[subject].shape[0] == voxels, "Invalid computation of SRM! (wrong # voxels in W)"
-        assert s.w_[subject].shape[1] == features, "Invalid computation of SRM! (wrong # features in W)"
-        ortho = np.linalg.norm(s.w_[subject].T.dot(s.w_[subject]) - np.eye(s.w_[subject].shape[1]), 'fro')
+        assert s.w_[subject].shape[0] == voxels, (
+            "Invalid computation of SRM! (wrong # voxels in W)")
+        assert s.w_[subject].shape[1] == features, (
+            "Invalid computation of SRM! (wrong # features in W)")
+        ortho = np.linalg.norm(s.w_[subject].T.dot(s.w_[subject])
+                               - np.eye(s.w_[subject].shape[1]),
+                               'fro')
         assert ortho < 1e-7, "A Wi mapping is not orthonormal in SRM."
-        difference = np.linalg.norm(X[subject] - s.w_[subject].dot(s.s_), 'fro')
+        difference = np.linalg.norm(X[subject] - s.w_[subject].dot(s.s_),
+                                    'fro')
         datanorm = np.linalg.norm(X[subject], 'fro')
         assert difference/datanorm < 1.0, "Model seems incorrectly computed."
-    assert s.s_.shape[0] == features, "Invalid computation of SRM! (wrong # features in S)"
-    assert s.s_.shape[1] == samples, "Invalid computation of SRM! (wrong # samples in S)"
+    assert s.s_.shape[0] == features, (
+        "Invalid computation of SRM! (wrong # features in S)")
+    assert s.s_.shape[1] == samples, (
+        "Invalid computation of SRM! (wrong # samples in S)")
 
-    # Check that it does run to compute the shared response after the model computation
+    # Check that it does run to compute the shared response after the model
+    # computation
     new_s = s.transform(X)
 
-    assert len(new_s) == subjects, "Invalid computation of SRM! (wrong # subjects after transform)"
+    assert len(new_s) == subjects, (
+        "Invalid computation of SRM! (wrong # subjects after transform)")
     for subject in range(subjects):
-        assert new_s[subject].shape[0] == features, "Invalid computation of SRM! (wrong # features after transform)"
-        assert new_s[subject].shape[1] == samples, "Invalid computation of SRM! (wrong # samples after transform)"
+        assert new_s[subject].shape[0] == features, (
+            "Invalid computation of SRM! (wrong # features after transform)")
+        assert new_s[subject].shape[1] == samples, (
+            "Invalid computation of SRM! (wrong # samples after transform)")
 
     # Check that it does NOT run with non-matching number of subjects
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         s.transform(X[1])
     print("Test: transforming with non-matching number of subjects")
 
     # Check that it does not run without enough samples (TRs).
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         s.set_params(features=(samples+1))
         s.fit(X)
     print("Test: not enough samples")
 
     # Check that it does not run with different number of samples (TRs)
-    S2 = S[:,:-2]
+    S2 = S[:, :-2]
     X.append(Q.dot(S2))
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         s.fit(X)
     print("Test: different number of samples per subject")
-
 
 
 def test_det_srm():
@@ -122,7 +133,6 @@ def test_det_srm():
     model = brainiak.funcalign.srm.DetSRM(n_iter=5, features=features)
     assert model, "Invalid DetSRM instance!"
 
-
     # Create a Shared response S with K = 3
     theta = np.linspace(-4 * np.pi, 4 * np.pi, samples)
     z = np.linspace(-2, 2, samples)
@@ -139,12 +149,12 @@ def test_det_srm():
     X.append(Q.dot(S) + 0.1*np.random.random((voxels, samples)))
 
     # Check that transform does NOT run before fitting the model
-    with pytest.raises(NotFittedError) as excinfo:
+    with pytest.raises(NotFittedError):
         model.transform(X)
     print("Test: transforming before fitting the model")
 
     # Check that it does NOT run with 1 subject
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         model.fit(X)
     print("Test: running DetSRM with 1 subject")
 
@@ -156,41 +166,54 @@ def test_det_srm():
     # Check that runs with 2 subject
     model.fit(X)
 
-    assert len(model.w_) == subjects, "Invalid computation of DetSRM! (wrong # subjects in W)"
+    assert len(model.w_) == subjects, (
+        "Invalid computation of DetSRM! (wrong # subjects in W)")
     for subject in range(subjects):
-        assert model.w_[subject].shape[0] == voxels, "Invalid computation of DetSRM! (wrong # voxels in W)"
-        assert model.w_[subject].shape[1] == features, "Invalid computation of DetSRM! (wrong # features in W)"
-        ortho = np.linalg.norm(model.w_[subject].T.dot(model.w_[subject]) - np.eye(model.w_[subject].shape[1]), 'fro')
+        assert model.w_[subject].shape[0] == voxels, (
+            "Invalid computation of DetSRM! (wrong # voxels in W)")
+        assert model.w_[subject].shape[1] == features, (
+            "Invalid computation of DetSRM! (wrong # features in W)")
+        ortho = np.linalg.norm(model.w_[subject].T.dot(model.w_[subject])
+                               - np.eye(model.w_[subject].shape[1]),
+                               'fro')
         assert ortho < 1e-7, "A Wi mapping is not orthonormal in DetSRM."
-        difference = np.linalg.norm(X[subject] - model.w_[subject].dot(model.s_), 'fro')
+        difference = np.linalg.norm(X[subject]
+                                    - model.w_[subject].dot(model.s_),
+                                    'fro')
         datanorm = np.linalg.norm(X[subject], 'fro')
         assert difference/datanorm < 1.0, "Model seems incorrectly computed."
-    assert model.s_.shape[0] == features, "Invalid computation of DetSRM! (wrong # features in S)"
-    assert model.s_.shape[1] == samples, "Invalid computation of DetSRM! (wrong # samples in S)"
+    assert model.s_.shape[0] == features, (
+        "Invalid computation of DetSRM! (wrong # features in S)")
+    assert model.s_.shape[1] == samples, (
+        "Invalid computation of DetSRM! (wrong # samples in S)")
 
-    # Check that it does run to compute the shared response after the model computation
+    # Check that it does run to compute the shared response after the model
+    # computation
     new_s = model.transform(X)
 
-    assert len(new_s) == subjects, "Invalid computation of DetSRM! (wrong # subjects after transform)"
+    assert len(new_s) == subjects, (
+        "Invalid computation of DetSRM! (wrong # subjects after transform)")
     for subject in range(subjects):
-        assert new_s[subject].shape[0] == features, "Invalid computation of DetSRM! (wrong # features after transform)"
-        assert new_s[subject].shape[1] == samples, "Invalid computation of DetSRM! (wrong # samples after transform)"
+        assert new_s[subject].shape[0] == features, (
+            "Invalid computation of DetSRM! (wrong # features after "
+            "transform)")
+        assert new_s[subject].shape[1] == samples, (
+            "Invalid computation of DetSRM! (wrong # samples after transform)")
 
     # Check that it does NOT run with non-matching number of subjects
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         model.transform(X[1])
     print("Test: transforming with non-matching number of subjects")
 
     # Check that it does not run without enough samples (TRs).
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         model.set_params(features=(samples+1))
         model.fit(X)
     print("Test: not enough samples")
 
     # Check that it does not run with different number of samples (TRs)
-    S2 = S[:,:-2]
+    S2 = S[:, :-2]
     X.append(Q.dot(S2))
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         model.fit(X)
     print("Test: different number of samples per subject")
-

--- a/tests/funcalign/test_sssrm.py
+++ b/tests/funcalign/test_sssrm.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 import pytest
 
+
 def test_instance():
     import os
     os.environ['THEANO_FLAGS'] = 'device=cpu, floatX=float64'
@@ -37,7 +38,8 @@ def test_wrong_input():
     features = 3
     n_labels = 4
 
-    model = brainiak.funcalign.sssrm.SSSRM(n_iter=5, features=features, gamma=10.0, alpha=0.1)
+    model = brainiak.funcalign.sssrm.SSSRM(n_iter=5, features=features,
+                                           gamma=10.0, alpha=0.1)
     assert model, "Invalid SSSRM instance!"
 
     # Create a Shared response S with K = 3
@@ -58,22 +60,25 @@ def test_wrong_input():
     Q, R = np.linalg.qr(np.random.random((voxels, features)))
     W.append(Q)
     X.append(Q.dot(S_align) + 0.1 * np.random.random((voxels, align_samples)))
-    Z.append(Q.dot(S_classify) + 0.1 * np.random.random((voxels, samples - align_samples)))
-    Z2.append(Q.dot(S_classify) + 0.1 * np.random.random((voxels, samples - align_samples)))
-    y.append(np.repeat(np.arange(n_labels), (samples - align_samples)/n_labels))
+    Z.append(Q.dot(S_classify)
+             + 0.1 * np.random.random((voxels, samples - align_samples)))
+    Z2.append(Q.dot(S_classify)
+              + 0.1 * np.random.random((voxels, samples - align_samples)))
+    y.append(np.repeat(
+        np.arange(n_labels), (samples - align_samples)/n_labels))
 
     # Check that transform does NOT run before fitting the model
-    with pytest.raises(NotFittedError) as excinfo:
+    with pytest.raises(NotFittedError):
         model.transform(X)
     print("Test: transforming before fitting the model")
 
     # Check that predict does NOT run before fitting the model
-    with pytest.raises(NotFittedError) as excinfo:
+    with pytest.raises(NotFittedError):
         model.predict(X)
     print("Test: predicting before fitting the model")
 
     # Check that it does NOT run with 1 subject on X
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         model.fit(X, y, Z)
     print("Test: running SSSRM with 1 subject (alignment)")
 
@@ -81,34 +86,39 @@ def test_wrong_input():
     for subject in range(1, subjects):
         Q, R = np.linalg.qr(np.random.random((voxels, features)))
         W.append(Q)
-        X.append(Q.dot(S_align) + 0.1 * np.random.random((voxels, align_samples)))
-        Z2.append(Q.dot(S_classify) + 0.1 * np.random.random((voxels, samples - align_samples)))
+        X.append(Q.dot(S_align)
+                 + 0.1 * np.random.random((voxels, align_samples)))
+        Z2.append(Q.dot(S_classify)
+                  + 0.1 * np.random.random((voxels, samples - align_samples)))
 
     # Check that it does NOT run with 1 subject on y
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         model.fit(X, y, Z)
     print("Test: running SSSRM with 1 subject (labels)")
 
     # Create more subjects labels data
     for subject in range(1, subjects):
-        y.append(np.repeat(np.arange(n_labels), (samples - align_samples)/n_labels))
+        y.append(np.repeat(
+            np.arange(n_labels), (samples - align_samples)/n_labels))
 
     # Check that it does NOT run with 1 subject on Z
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         model.fit(X, y, Z)
     print("Test: running SSSRM with 1 subject (classif.)")
 
     # Check that alpha is in (0,1) range
-    model_bad = brainiak.funcalign.sssrm.SSSRM(n_iter=1, features=features, gamma=10.0, alpha=1.5)
+    model_bad = brainiak.funcalign.sssrm.SSSRM(n_iter=1, features=features,
+                                               gamma=10.0, alpha=1.5)
     assert model_bad, "Invalid SSSRM instance!"
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         model_bad.fit(X, y, Z)
     print("Test: running SSSRM with wrong alpha")
 
     # Check that gamma is positive
-    model_bad = brainiak.funcalign.sssrm.SSSRM(n_iter=1, features=features, gamma=-0.1, alpha=0.2)
+    model_bad = brainiak.funcalign.sssrm.SSSRM(n_iter=1, features=features,
+                                               gamma=-0.1, alpha=0.2)
     assert model_bad, "Invalid SSSRM instance!"
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         model_bad.fit(X, y, Z)
     print("Test: running SSSRM with wrong gamma")
 
@@ -117,7 +127,6 @@ def test_sssrm():
     import os
     os.environ['THEANO_FLAGS'] = 'device=cpu, floatX=float64'
 
-    from sklearn.utils.validation import NotFittedError
     import numpy as np
     import brainiak.funcalign.sssrm
 
@@ -128,7 +137,8 @@ def test_sssrm():
     features = 3
     n_labels = 4
 
-    model = brainiak.funcalign.sssrm.SSSRM(n_iter=5, features=features, gamma=10.0, alpha=0.1)
+    model = brainiak.funcalign.sssrm.SSSRM(n_iter=5, features=features,
+                                           gamma=10.0, alpha=0.1)
     assert model, "Invalid SSSRM instance!"
 
     # Create a Shared response S with K = 3
@@ -147,19 +157,25 @@ def test_sssrm():
     y = []
     Q, R = np.linalg.qr(np.random.random((voxels, features)))
     X.append(Q.dot(S_align) + 0.1 * np.random.random((voxels, align_samples)))
-    Z.append(Q.dot(S_classify) + 0.1 * np.random.random((voxels, samples - align_samples)))
-    Z2.append(Q.dot(S_classify) + 0.1 * np.random.random((voxels, samples - align_samples)))
-    y.append(np.repeat(np.arange(n_labels), (samples - align_samples)/n_labels))
+    Z.append(Q.dot(S_classify)
+             + 0.1 * np.random.random((voxels, samples - align_samples)))
+    Z2.append(Q.dot(S_classify)
+              + 0.1 * np.random.random((voxels, samples - align_samples)))
+    y.append(np.repeat(
+        np.arange(n_labels), (samples - align_samples)/n_labels))
 
     # Create more subjects align and classification data
     for subject in range(1, subjects):
         Q, R = np.linalg.qr(np.random.random((voxels, features)))
-        X.append(Q.dot(S_align) + 0.1 * np.random.random((voxels, align_samples)))
-        Z2.append(Q.dot(S_classify) + 0.1 * np.random.random((voxels, samples - align_samples)))
+        X.append(Q.dot(S_align)
+                 + 0.1 * np.random.random((voxels, align_samples)))
+        Z2.append(Q.dot(S_classify)
+                  + 0.1 * np.random.random((voxels, samples - align_samples)))
 
     # Create more subjects labels data
     for subject in range(1, subjects):
-        y.append(np.repeat(np.arange(n_labels), (samples - align_samples)/n_labels))
+        y.append(np.repeat(
+            np.arange(n_labels), (samples - align_samples)/n_labels))
 
     # Set the logging level to INFO
     import logging
@@ -169,65 +185,85 @@ def test_sssrm():
     model.fit(X, y, Z2)
     print("Test: fitting SSSRM successfully")
 
-    assert len(model.w_) == subjects, "Invalid computation of SSSRM! (wrong # subjects in W)"
+    assert len(model.w_) == subjects, (
+        "Invalid computation of SSSRM! (wrong # subjects in W)")
     for subject in range(subjects):
-        assert model.w_[subject].shape[0] == voxels, "Invalid computation of SSSRM! (wrong # voxels in W)"
-        assert model.w_[subject].shape[1] == features, "Invalid computation of SSSRM! (wrong # features in W)"
-        ortho = np.linalg.norm(model.w_[subject].T.dot(model.w_[subject]) - np.eye(model.w_[subject].shape[1]), 'fro')
+        assert model.w_[subject].shape[0] == voxels, (
+            "Invalid computation of SSSRM! (wrong # voxels in W)")
+        assert model.w_[subject].shape[1] == features, (
+            "Invalid computation of SSSRM! (wrong # features in W)")
+        ortho = np.linalg.norm(model.w_[subject].T.dot(model.w_[subject])
+                               - np.eye(model.w_[subject].shape[1]),
+                               'fro')
         assert ortho < 1e-7, "A Wi mapping is not orthonormal in SSSRM."
-        difference = np.linalg.norm(X[subject] - model.w_[subject].dot(model.s_), 'fro')
+        difference = np.linalg.norm(X[subject]
+                                    - model.w_[subject].dot(model.s_),
+                                    'fro')
         datanorm = np.linalg.norm(X[subject], 'fro')
         assert difference/datanorm < 1.0, "Model seems incorrectly computed."
-    assert model.s_.shape[0] == features, "Invalid computation of SSSRM! (wrong # features in S)"
-    assert model.s_.shape[1] == align_samples, "Invalid computation of SSSRM! (wrong # samples in S)"
+    assert model.s_.shape[0] == features, (
+        "Invalid computation of SSSRM! (wrong # features in S)")
+    assert model.s_.shape[1] == align_samples, (
+        "Invalid computation of SSSRM! (wrong # samples in S)")
 
-    # Check that it does run to compute the shared response after the model computation
+    # Check that it does run to compute the shared response after the model
+    # computation
     new_s = model.transform(X)
     print("Test: transforming with SSSRM successfully")
 
-    assert len(new_s) == subjects, "Invalid computation of SSSRM! (wrong # subjects after transform)"
+    assert len(new_s) == subjects, (
+        "Invalid computation of SSSRM! (wrong # subjects after transform)")
     for subject in range(subjects):
-        assert new_s[subject].shape[0] == features, "Invalid computation of SSSRM! (wrong # features after transform)"
-        assert new_s[subject].shape[1] == align_samples, "Invalid computation of SSSRM! (wrong # samples after transform)"
+        assert new_s[subject].shape[0] == features, (
+            "Invalid computation of SSSRM! (wrong # features after transform)")
+        assert new_s[subject].shape[1] == align_samples, (
+            "Invalid computation of SSSRM! (wrong # samples after transform)")
 
     # Check that it predicts with the model
     pred = model.predict(Z2)
     print("Test: predicting with SSSRM successfully")
-    assert len(pred) == subjects, "Invalid computation of SSSRM! (wrong # subjects after predict)"
+    assert len(pred) == subjects, (
+        "Invalid computation of SSSRM! (wrong # subjects after predict)")
     for subject in range(subjects):
-        assert pred[subject].size == samples - align_samples, "SSSRM: wrong # answers in predict"
-        pred_labels = np.logical_and(pred[subject] >=0, pred[subject] < n_labels)
-        assert np.all(pred_labels), "SSSRM: wrong class number output in predict"
+        assert pred[subject].size == samples - align_samples, (
+            "SSSRM: wrong # answers in predict")
+        pred_labels = np.logical_and(pred[subject] >= 0,
+                                     pred[subject] < n_labels)
+        assert np.all(pred_labels), (
+            "SSSRM: wrong class number output in predict")
 
     # Check that it does NOT run with non-matching number of subjects
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         model.transform(X[1])
     print("Test: transforming with non-matching number of subjects")
 
     # Check that it does not run without enough samples (TRs).
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError):
         model.set_params(features=(align_samples + 1))
         model.fit(X, y, Z2)
     print("Test: not enough samples")
 
     # Check that it does not run with different number of samples (TRs)
     X2 = X
-    X2[0] = Q.dot(S[:,:-2])
-    with pytest.raises(ValueError) as excinfo:
+    X2[0] = Q.dot(S[:, :-2])
+    with pytest.raises(ValueError):
         model.fit(X2, y, Z2)
     print("Test: different number of samples per subject")
 
     # Create one more subject
     Q, R = np.linalg.qr(np.random.random((voxels, features)))
     X.append(Q.dot(S_align) + 0.1 * np.random.random((voxels, align_samples)))
-    Z2.append(Q.dot(S_classify) + 0.1 * np.random.random((voxels, samples - align_samples)))
+    Z2.append(Q.dot(S_classify)
+              + 0.1 * np.random.random((voxels, samples - align_samples)))
 
-    # Check that it does not run with different number of subjects in each input
-    with pytest.raises(ValueError) as excinfo:
+    # Check that it does not run with different number of subjects in each
+    # input
+    with pytest.raises(ValueError):
         model.fit(X, y, Z2)
     print("Test: different number of subjects in the inputs")
 
-    y.append(np.repeat(np.arange(n_labels), (samples - align_samples)/n_labels))
-    with pytest.raises(ValueError) as excinfo:
+    y.append(np.repeat(
+        np.arange(n_labels), (samples - align_samples)/n_labels))
+    with pytest.raises(ValueError):
         model.fit(X, y, Z)
     print("Test: different number of subjects in the inputs")

--- a/tests/hyperparamopt/test_hpo.py
+++ b/tests/hyperparamopt/test_hpo.py
@@ -40,28 +40,28 @@ def test_simple_gmm_weights():
     y2 = d2(np.array([1.1, 2.0]))
 
     assert d2(1.1) == y2[0],\
-           "GMM distribution array & scalar results don't match"
+        "GMM distribution array & scalar results don't match"
     assert np.abs(d(1.1) - d2(1.1)) < 1e-5,\
-           "GMM distribution weights not handled correctly"
+        "GMM distribution weights not handled correctly"
     assert np.abs(d(2.0) - d2(2.0)) < 1e-5,\
-           "GMM distribution weights not handled correctly"
+        "GMM distribution weights not handled correctly"
 
 
 def test_simple_hpo():
 
     def f(args):
-      x = args['x']
-      return x*x
+        x = args['x']
+        return x*x
 
     s = {'x': {'dist': st.uniform(loc=-10., scale=20), 'lo': -10., 'hi': 10.}}
     trials = []
 
-    #Test fmin and ability to continue adding to trials
+    # Test fmin and ability to continue adding to trials
     best = fmin(loss_fn=f, space=s, max_evals=40, trials=trials)
     best = fmin(loss_fn=f, space=s, max_evals=10, trials=trials)
 
     assert len(trials) == 50, "HPO continuation trials not working"
-    
+
     # Test verbose flag
     best = fmin(loss_fn=f, space=s, max_evals=10, trials=trials)
 
@@ -74,14 +74,13 @@ def test_simple_hpo():
     assert best['loss'] < 100., "HPO out of range"
     assert np.abs(best['x']) < 10., "HPO out of range"
 
-    #Test unknown distributions
+    # Test unknown distributions
     s2 = {'x': {'dist': 'normal', 'mu': 0., 'sigma': 1.}}
     trials2 = []
     with pytest.raises(ValueError) as excinfo:
-        best2 = fmin(loss_fn=f, space=s2, max_evals=40, trials=trials2)
+        fmin(loss_fn=f, space=s2, max_evals=40, trials=trials2)
     assert "Unknown distribution type for variable" in str(excinfo.value)
 
     s3 = {'x': {'dist': st.norm(loc=0., scale=1.)}}
     trials3 = []
-    best3 = fmin(loss_fn=f, space=s3, max_evals=40, trials=trials3)
-
+    fmin(loss_fn=f, space=s3, max_evals=40, trials=trials3)

--- a/tests/isfc/test_isfc.py
+++ b/tests/isfc/test_isfc.py
@@ -1,45 +1,47 @@
 import brainiak.isfc
 from brainiak import image, io
 import numpy as np
-import sys, os
+import os
+
 
 def test_ISC():
-    D = np.zeros((2,5,3))
-    D[:,:,0] = \
-        [[-0.36225433, -0.43482456,  0.26723158,  0.16461712, -0.37991465], \
+    D = np.zeros((2, 5, 3))
+    D[:, :, 0] = \
+        [[-0.36225433, -0.43482456,  0.26723158,  0.16461712, -0.37991465],
          [-0.62305959, -0.46660116, -0.50037994,  1.81083754,  0.23499509]]
-    D[:,:,1] = \
-        [[-0.31484153, -0.47486988,  0.18966625, -0.12568572, -0.40535156], \
-         [-0.78433298, -0.35875085, -0.6121344 ,  1.68267639,  0.28603493]]
-    D[:,:,2] = \
-        [[-0.26593192, -0.56914734,  0.28397317,  0.30276589, -0.42637472], \
+    D[:, :, 1] = \
+        [[-0.31484153, -0.47486988,  0.18966625, -0.12568572, -0.40535156],
+         [-0.78433298, -0.35875085, -0.6121344,  1.68267639,  0.28603493]]
+    D[:, :, 2] = \
+        [[-0.26593192, -0.56914734,  0.28397317,  0.30276589, -0.42637472],
          [-0.67598379, -0.51549055, -0.64196342,  1.60686666,  0.04127293]]
 
     ISC = brainiak.isfc.isc(D)
     assert np.isclose(ISC, [0.9540602, 0.99585304]).all(), \
         "Calculated ISC does not match ground truth"
 
+
 def test_ISFC():
     curr_dir = os.path.dirname(__file__)
 
-    mask_fname = os.path.join(curr_dir,'mask.nii.gz')
+    mask_fname = os.path.join(curr_dir, 'mask.nii.gz')
     mask = io.load_boolean_mask(mask_fname)
-    fnames = [os.path.join(curr_dir,'subj1.nii.gz'),
-              os.path.join(curr_dir,'subj2.nii.gz')]
+    fnames = [os.path.join(curr_dir, 'subj1.nii.gz'),
+              os.path.join(curr_dir, 'subj2.nii.gz')]
     masked_images = image.mask_images(io.load_images(fnames), mask)
 
     D = image.MaskedMultiSubjectData.from_masked_images(masked_images,
                                                         len(fnames))
 
-    assert D.shape == (4,5,2), "Loaded data has incorrect shape"
+    assert D.shape == (4, 5, 2), "Loaded data has incorrect shape"
 
     ISFC = brainiak.isfc.isfc(D)
-    
+
     ground_truth = \
-        [[ 1,  1,  0, -1],
-         [ 1,  1,  0, -1],
-         [ 0,  0,  1,  0],
-         [-1, -1,  0,  1]]
+        [[1, 1, 0, -1],
+         [1, 1, 0, -1],
+         [0, 0, 1,  0],
+         [-1, -1, 0, 1]]
 
     assert np.isclose(ISFC, ground_truth).all(), \
         "Calculated ISFC does not match ground truth"

--- a/tests/reprsimil/test_brsa.py
+++ b/tests/reprsimil/test_brsa.py
@@ -12,25 +12,21 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-from sklearn.utils.validation import NotFittedError
 import pytest
 
 
 def test_can_instantiate():
     import brainiak.reprsimil.brsa
-    import numpy as np
     s = brainiak.reprsimil.brsa.BRSA()
     assert s, "Invalid BRSA instance!"
 
-    s = brainiak.reprsimil.brsa.BRSA(n_iter=50, rank=5,
-                                     auto_nuisance=False, n_nureg=2, nureg_method='ICA',
-                                     baseline_single=False, init_iter=5,
-                                     GP_space=True, GP_inten=True, tol=2e-3,
-                                     eta=0.001, space_smooth_range=10.0,
-                                     inten_smooth_range=100.0, tau_range=2.0,
-                                     tau2_prior=brainiak.reprsimil.brsa.prior_GP_var_inv_gamma,
-                                     optimizer='CG',
-                                     random_state=100, anneal_speed=20)
+    s = brainiak.reprsimil.brsa.BRSA(
+        n_iter=50, rank=5, auto_nuisance=False, n_nureg=2, nureg_method='ICA',
+        baseline_single=False, init_iter=5, GP_space=True, GP_inten=True,
+        tol=2e-3, eta=0.001, space_smooth_range=10.0, inten_smooth_range=100.0,
+        tau_range=2.0,
+        tau2_prior=brainiak.reprsimil.brsa.prior_GP_var_inv_gamma,
+        optimizer='CG', random_state=100, anneal_speed=20)
     assert s, "Invalid BRSA instance!"
 
 
@@ -81,13 +77,14 @@ def test_fit():
     ideal_cov[5:9, 5:9] = 0.9
     for cond in range(5, 9):
         ideal_cov[cond, cond] = 1
-    idx = np.where(np.sum(np.abs(ideal_cov), axis=0) > 0)[0]
+    idx = np.where(np.sum(np.abs(ideal_cov), axis=0) > 0)[0]  # noqa: F841
     L_full = np.linalg.cholesky(ideal_cov)
 
     # generating signal
     snr_level = 5.0  # test with high SNR
     # snr = np.random.rand(n_V)*(snr_top-snr_bot)+snr_bot
-    # Notice that accurately speaking this is not snr. the magnitude of signal depends
+    # Notice that accurately speaking this is not snr. the magnitude of signal
+    # depends
     # not only on beta but also on x.
     inten = np.random.rand(n_V) * 20.0
 
@@ -127,8 +124,8 @@ def test_fit():
     with pytest.raises(ValueError) as excinfo:
         brsa.fit(X=Y, design=wrong_design, scan_onsets=scan_onsets,
                  coords=coords, inten=inten)
-    assert 'Your design matrix appears to have included baseline time series.' in str(
-        excinfo.value)
+    assert ('Your design matrix appears to have included baseline time series.'
+            in str(excinfo.value))
     # Now we fit with the correct design matrix.
     brsa.fit(X=Y, design=design.design_task, scan_onsets=scan_onsets,
              coords=coords, inten=inten)
@@ -139,15 +136,19 @@ def test_fit():
     u_i = ideal_cov
     p = scipy.stats.spearmanr(u_b[np.tril_indices_from(u_b)],
                               u_i[np.tril_indices_from(u_i)])[1]
-    assert p < 0.01, "Fitted covariance matrix does not correlate with ideal covariance matrix!"
+    assert p < 0.01, (
+        "Fitted covariance matrix does not correlate with ideal covariance "
+        "matrix!")
     # check that the recovered SNRs makes sense
     p = scipy.stats.pearsonr(brsa.nSNR_, snr)[1]
     assert p < 0.01, "Fitted SNR does not correlate with simulated SNR!"
     assert np.isclose(np.mean(np.log(brsa.nSNR_)), 0), "nSNR_ not normalized!"
     p = scipy.stats.pearsonr(brsa.sigma_, noise_level)[1]
-    assert p < 0.01, "Fitted noise level does not correlate with simulated noise level!"
+    assert p < 0.01, (
+        "Fitted noise level does not correlate with simulated noise level!")
     p = scipy.stats.pearsonr(brsa.rho_, rho1)[1]
-    assert p < 0.01, "Fitted AR(1) coefficient does not correlate with simulated values!"
+    assert p < 0.01, (
+        "Fitted AR(1) coefficient does not correlate with simulated values!")
 
     noise_new = np.zeros([n_T, n_V])
     noise_new[0, :] = np.random.randn(n_V) * noise_level / np.sqrt(1 - rho1**2)
@@ -158,17 +159,21 @@ def test_fit():
     Y_new = signal + noise_new + inten
     ts, ts0 = brsa.transform(Y_new, scan_onsets=scan_onsets)
     p = scipy.stats.pearsonr(ts[:, 0], design.design_task[:, 0])[1]
-    assert p < 0.01, "Recovered time series does not correlate with true time series!"
-    assert np.shape(ts) == (n_T, n_C) and np.shape(ts0) == (n_T, 1),\
-        "Wrong shape in returned time series by transform function!"
+    assert p < 0.01, (
+        "Recovered time series does not correlate with true time series!")
+    assert np.shape(ts) == (n_T, n_C) and np.shape(ts0) == (n_T, 1), (
+        "Wrong shape in returned time series by transform function!")
 
     [score, score_null] = brsa.score(
         X=Y_new, design=design.design_task, scan_onsets=scan_onsets)
-    assert score > score_null, "Full model does not win over null model on data containing signal"
+    assert score > score_null, (
+        "Full model does not win over null model on data containing signal")
 
-    [score, score_null] = brsa.score(
-        X=noise_new + inten, design=design.design_task, scan_onsets=scan_onsets)
-    assert score < score_null, "Null model does not win over full model on data without signal"
+    [score, score_null] = brsa.score(X=noise_new + inten,
+                                     design=design.design_task,
+                                     scan_onsets=scan_onsets)
+    assert score < score_null, (
+        "Null model does not win over full model on data without signal")
 
     # Test fitting with lower rank, nuisance regressors and without GP prior
     rank = n_C - 1
@@ -180,22 +185,30 @@ def test_fit():
     u_i = ideal_cov
     p = scipy.stats.spearmanr(u_b[np.tril_indices_from(u_b)], u_i[
                               np.tril_indices_from(u_i)])[1]
-    assert p < 0.01, "Fitted covariance matrix does not correlate with ideal covariance matrix!"
+    assert p < 0.01, (
+        "Fitted covariance matrix does not correlate with ideal covariance "
+        "matrix!")
     # check that the recovered SNRs makes sense
     p = scipy.stats.pearsonr(brsa.nSNR_, snr)[1]
     assert p < 0.01, "Fitted SNR does not correlate with simulated SNR!"
     assert np.isclose(np.mean(np.log(brsa.nSNR_)), 0), "nSNR_ not normalized!"
     p = scipy.stats.pearsonr(brsa.sigma_, noise_level)[1]
-    assert p < 0.01, "Fitted noise level does not correlate with simulated noise level!"
+    assert p < 0.01, (
+        "Fitted noise level does not correlate with simulated noise level!")
     p = scipy.stats.pearsonr(brsa.rho_, rho1)[1]
-    assert p < 0.01, "Fitted AR(1) coefficient does not correlate with simulated values!"
+    assert p < 0.01, (
+        "Fitted AR(1) coefficient does not correlate with simulated values!")
 
-    assert not hasattr(brsa, 'bGP_') and not hasattr(brsa, 'lGPspace_') and not hasattr(brsa, 'lGPinten_'),\
-        'the BRSA object should not have parameters of GP if GP is not requested.'
+    assert (not hasattr(brsa, 'bGP_')
+            and not hasattr(brsa, 'lGPspace_')
+            and not hasattr(brsa, 'lGPinten_')
+            ), ("the BRSA object should not have parameters of GP if GP is "
+                "not requested.")
     # GP parameters are not set if not requested
     assert brsa.beta0_.shape[0] == n_nureg + 1, 'Shape of beta0 incorrect'
     p = scipy.stats.pearsonr(brsa.beta0_[0, :], inten)[1]
-    assert p < 0.01, 'recovered beta0 does not correlate with the baseline of voxels.'
+    assert p < 0.01, (
+        'recovered beta0 does not correlate with the baseline of voxels.')
     assert np.shape(brsa.L_) == (
         n_C, rank), 'Cholesky factor should have shape of (n_C, rank)'
 
@@ -204,29 +217,34 @@ def test_fit():
                 tol=2e-3, n_iter=4, init_iter=4)
     brsa.fit(X=Y, design=design.design_task,
              scan_onsets=scan_onsets, coords=coords)
-    # # Check that result is significantly correlated with the ideal covariance matrix
+    # Check that result is significantly correlated with the ideal covariance
+    # matrix
     u_b = brsa.U_
     u_i = ideal_cov
     p = scipy.stats.spearmanr(u_b[np.tril_indices_from(u_b)], u_i[
                               np.tril_indices_from(u_i)])[1]
-    assert p < 0.01, "Fitted covariance matrix does not correlate with ideal covariance matrix!"
+    assert p < 0.01, (
+        "Fitted covariance matrix does not correlate with ideal covariance "
+        "matrix!")
     # check that the recovered SNRs makes sense
     p = scipy.stats.pearsonr(brsa.nSNR_, snr)[1]
     assert p < 0.01, "Fitted SNR does not correlate with simulated SNR!"
     assert np.isclose(np.mean(np.log(brsa.nSNR_)), 0), "nSNR_ not normalized!"
     p = scipy.stats.pearsonr(brsa.sigma_, noise_level)[1]
-    assert p < 0.01, "Fitted noise level does not correlate with simulated noise level!"
+    assert p < 0.01, (
+        "Fitted noise level does not correlate with simulated noise level!")
     p = scipy.stats.pearsonr(brsa.rho_, rho1)[1]
-    assert p < 0.01, "Fitted AR(1) coefficient does not correlate with simulated values!"
-    assert not hasattr(brsa, 'lGPinten_'),\
-        'the BRSA object should not have parameters of lGPinten_ if only smoothness in space is requested.'
+    assert p < 0.01, (
+        "Fitted AR(1) coefficient does not correlate with simulated values!")
+    assert not hasattr(brsa, 'lGPinten_'), (
+        "the BRSA object should not have parameters of lGPinten_ if only "
+        "smoothness in space is requested.")
     # GP parameters are not set if not requested
 
 
 def test_gradient():
     from brainiak.reprsimil.brsa import BRSA
     import brainiak.utils.utils as utils
-    import scipy.stats
     import numpy as np
     import os.path
     import numdifftools as nd
@@ -269,7 +287,7 @@ def test_gradient():
     ideal_cov[5:9, 5:9] = 0.6
     for cond in range(5, 9):
         ideal_cov[cond, cond] = 1
-    idx = np.where(np.sum(np.abs(ideal_cov), axis=0) > 0)[0]
+    idx = np.where(np.sum(np.abs(ideal_cov), axis=0) > 0)[0]  # noqa: F841
     L_full = np.linalg.cholesky(ideal_cov)
 
     # generating signal
@@ -293,8 +311,8 @@ def test_gradient():
 
     L = np.linalg.cholesky(K)
     snr = np.exp(np.dot(L, np.random.randn(n_V))) * snr_level
-    # Notice that accurately speaking this is not snr. the magnitude of signal depends
-    # not only on beta but also on x.
+    # Notice that accurately speaking this is not snr. the magnitude of signal
+    # depends not only on beta but also on x.
     sqrt_v = noise_level * snr
     betas_simulated = np.dot(L_full, np.random.randn(n_C, n_V)) * sqrt_v
     signal = np.dot(design.design_task, betas_simulated)
@@ -315,31 +333,48 @@ def test_gradient():
     assert np.shape(F) == (n_T, n_T), 'F has wrong shape'
     assert np.sum(D) == (n_T - n_run) * 2, 'D is initialized incorrectly.'
     assert np.sum(F) == n_T - n_run * 2, 'F is initialized incorrectly.'
-    assert n_run_returned == n_run, 'There is mistake in counting number of runs'
-    assert np.sum(
-        run_TRs) == n_T, 'The segmentation of the total experiment duration is wrong'
-    XTY, XTDY, XTFY, YTY_diag, YTDY_diag, YTFY_diag, XTX, \
-        XTDX, XTFX = brsa._prepare_data_XY(design.design_task, Y, D, F)
-    X0TX0, X0TDX0, X0TFX0, XTX0, XTDX0, XTFX0, \
-        X0TY, X0TDY, X0TFY, X0, X_base, n_X0, idx_DC \
-        = brsa._prepare_data_XYX0(
-            design.design_task, Y, X0, np.random.randn(n_T)[:, None], D, F, run_TRs, no_DC=False)
-    assert np.shape(XTY) == (n_C, n_V) and np.shape(XTDY) == (n_C, n_V) \
-        and np.shape(XTFY) == (n_C, n_V),\
-        'Dimension of XTY etc. returned from _prepare_data is wrong'
-    assert np.ndim(YTY_diag) == 1 and np.ndim(YTDY_diag) == 1 and np.ndim(YTFY_diag) == 1,\
-        'Dimension of YTY_diag etc. returned from _prepare_data is wrong'
-    assert np.ndim(XTX) == 2 and np.ndim(XTDX) == 2 and np.ndim(XTFX) == 2,\
-        'Dimension of XTX etc. returned from _prepare_data is wrong'
-    assert np.ndim(X0TX0) == 2 and np.ndim(X0TDX0) == 2 and np.ndim(X0TFX0) == 2,\
-        'Dimension of X0TX0 etc. returned from _prepare_data is wrong'
-    assert np.ndim(XTX0) == 2 and np.ndim(XTDX0) == 2 and np.ndim(XTFX0) == 2,\
-        'Dimension of XTX0 etc. returned from _prepare_data is wrong'
-    assert np.ndim(X0TY) == 2 and np.ndim(X0TDY) == 2 and np.ndim(X0TFY) == 2,\
-        'Dimension of X0TY etc. returned from _prepare_data is wrong'
-    assert np.shape(X0) == (n_T, n_X0) and np.shape(X_base) == (n_T, np.size(idx_DC)) and np.max(idx_DC) < n_X0\
-        and  np.size(idx_DC) + 1 == n_X0,\
-        'Dimension of X0 or X_base, or n_X0 or indices of DC components are wrong.'
+    assert n_run_returned == n_run, (
+        'There is mistake in counting number of runs')
+    assert np.sum(run_TRs) == n_T, (
+        'The segmentation of the total experiment duration is wrong')
+    (XTY, XTDY, XTFY, YTY_diag, YTDY_diag, YTFY_diag, XTX, XTDX, XTFX
+     ) = brsa._prepare_data_XY(design.design_task, Y, D, F)
+    (X0TX0, X0TDX0, X0TFX0, XTX0, XTDX0, XTFX0, X0TY, X0TDY, X0TFY, X0, X_base,
+     n_X0, idx_DC
+     ) = brsa._prepare_data_XYX0(design.design_task, Y, X0,
+                                 np.random.randn(n_T)[:, None], D, F, run_TRs,
+                                 no_DC=False)
+    assert (np.shape(XTY) == (n_C, n_V)
+            and np.shape(XTDY) == (n_C, n_V)
+            and np.shape(XTFY) == (n_C, n_V)
+            ), 'Dimension of XTY etc. returned from _prepare_data is wrong'
+    assert (np.ndim(YTY_diag) == 1
+            and np.ndim(YTDY_diag) == 1
+            and np.ndim(YTFY_diag) == 1
+            ), ("Dimension of YTY_diag etc. returned from _prepare_data is "
+                "wrong")
+    assert (np.ndim(XTX) == 2
+            and np.ndim(XTDX) == 2
+            and np.ndim(XTFX) == 2
+            ), 'Dimension of XTX etc. returned from _prepare_data is wrong'
+    assert (np.ndim(X0TX0) == 2
+            and np.ndim(X0TDX0) == 2
+            and np.ndim(X0TFX0) == 2
+            ), 'Dimension of X0TX0 etc. returned from _prepare_data is wrong'
+    assert (np.ndim(XTX0) == 2
+            and np.ndim(XTDX0) == 2
+            and np.ndim(XTFX0) == 2
+            ), 'Dimension of XTX0 etc. returned from _prepare_data is wrong'
+    assert (np.ndim(X0TY) == 2
+            and np.ndim(X0TDY) == 2
+            and np.ndim(X0TFY) == 2
+            ), 'Dimension of X0TY etc. returned from _prepare_data is wrong'
+    assert (np.shape(X0) == (n_T, n_X0)
+            and np.shape(X_base) == (n_T, np.size(idx_DC))
+            and np.max(idx_DC) < n_X0
+            and np.size(idx_DC) + 1 == n_X0
+            ), ("Dimension of X0 or X_base, or n_X0 or indices of DC "
+                "components are wrong.")
     l_idx = np.tril_indices(n_C)
     n_l = np.size(l_idx[0])
 
@@ -366,76 +401,99 @@ def test_gradient():
     # test if the gradients are correct
     # log likelihood and derivative of the _singpara function
 
-    ll0, deriv0 = brsa._loglike_AR1_singpara(param0_sing, XTX, XTDX, XTFX, YTY_diag, YTDY_diag, YTFY_diag,
-                                             XTY, XTDY, XTFY, X0TX0, X0TDX0, X0TFX0,
-                                             XTX0, XTDX0, XTFX0, X0TY, X0TDY, X0TFY,
-                                             l_idx, n_C, n_T, n_V, n_run, n_X0,
-                                             idx_param_sing)
+    ll0, deriv0 = brsa._loglike_AR1_singpara(param0_sing, XTX, XTDX, XTFX,
+                                             YTY_diag, YTDY_diag, YTFY_diag,
+                                             XTY, XTDY, XTFY, X0TX0, X0TDX0,
+                                             X0TFX0, XTX0, XTDX0, XTFX0, X0TY,
+                                             X0TDY, X0TFY, l_idx, n_C, n_T,
+                                             n_V, n_run, n_X0, idx_param_sing)
     # We test the gradient to the Cholesky factor
     vec = np.zeros(np.size(param0_sing))
     vec[idx_param_sing['Cholesky'][0]] = 1
-    dd = nd.directionaldiff(lambda x: brsa._loglike_AR1_singpara(x, XTX, XTDX, XTFX, YTY_diag, YTDY_diag, YTFY_diag,
-                                                                 XTY, XTDY, XTFY, X0TX0, X0TDX0, X0TFX0,
-                                                                 XTX0, XTDX0, XTFX0, X0TY, X0TDY, X0TFY,
-                                                                 l_idx, n_C, n_T, n_V, n_run, n_X0,
-                                                                 idx_param_sing)[0],
-                            param0_sing, vec)
-    assert np.isclose(dd, np.dot(deriv0, vec),
-                      rtol=1e-5), 'gradient of singpara wrt Cholesky is incorrect'
+    dd = nd.directionaldiff(
+        lambda x: brsa._loglike_AR1_singpara(x, XTX, XTDX, XTFX, YTY_diag,
+                                             YTDY_diag, YTFY_diag, XTY, XTDY,
+                                             XTFY, X0TX0, X0TDX0, X0TFX0, XTX0,
+                                             XTDX0, XTFX0, X0TY, X0TDY, X0TFY,
+                                             l_idx, n_C, n_T, n_V, n_run, n_X0,
+                                             idx_param_sing)[0],
+        param0_sing,
+        vec)
+    assert np.isclose(dd, np.dot(deriv0, vec), rtol=1e-5), (
+        'gradient of singpara wrt Cholesky is incorrect')
 
     # We test the gradient to a1
     vec = np.zeros(np.size(param0_sing))
     vec[idx_param_sing['a1']] = 1
-    dd = nd.directionaldiff(lambda x: brsa._loglike_AR1_singpara(x, XTX, XTDX, XTFX, YTY_diag, YTDY_diag, YTFY_diag,
-                                                                 XTY, XTDY, XTFY, X0TX0, X0TDX0, X0TFX0,
-                                                                 XTX0, XTDX0, XTFX0, X0TY, X0TDY, X0TFY,
-                                                                 l_idx, n_C, n_T, n_V, n_run, n_X0,
-                                                                 idx_param_sing)[0],
-                            param0_sing, vec)
+    dd = nd.directionaldiff(
+        lambda x: brsa._loglike_AR1_singpara(x, XTX, XTDX, XTFX, YTY_diag,
+                                             YTDY_diag, YTFY_diag, XTY, XTDY,
+                                             XTFY, X0TX0, X0TDX0, X0TFX0, XTX0,
+                                             XTDX0, XTFX0, X0TY, X0TDY, X0TFY,
+                                             l_idx, n_C, n_T, n_V, n_run, n_X0,
+                                             idx_param_sing)[0],
+        param0_sing,
+        vec)
     assert np.isclose(dd, np.dot(deriv0, vec),
                       rtol=1e-5), 'gradient of singpara wrt a1 is incorrect'
 
     # log likelihood and derivative of the fitU function.
-    ll0, deriv0 = brsa._loglike_AR1_diagV_fitU(param0_fitU, XTX, XTDX, XTFX, YTY_diag, YTDY_diag, YTFY_diag,
-                                               XTY, XTDY, XTFY, X0TX0, X0TDX0, X0TFX0,
-                                               XTX0, XTDX0, XTFX0, X0TY, X0TDY, X0TFY,
-                                               np.log(snr) * 2, l_idx, n_C, n_T, n_V, n_run, n_X0, idx_param_fitU, n_C)
+    ll0, deriv0 = brsa._loglike_AR1_diagV_fitU(param0_fitU, XTX, XTDX, XTFX,
+                                               YTY_diag, YTDY_diag, YTFY_diag,
+                                               XTY, XTDY, XTFY, X0TX0, X0TDX0,
+                                               X0TFX0, XTX0, XTDX0, XTFX0,
+                                               X0TY, X0TDY, X0TFY, np.log(snr)
+                                               * 2, l_idx, n_C, n_T, n_V,
+                                               n_run, n_X0, idx_param_fitU,
+                                               n_C)
 
     # We test the gradient wrt the reparametrization of AR(1) coefficient of
     # noise.
     vec = np.zeros(np.size(param0_fitU))
     vec[idx_param_fitU['a1'][0]] = 1
-    dd = nd.directionaldiff(lambda x: brsa._loglike_AR1_diagV_fitU(x, XTX, XTDX, XTFX, YTY_diag, YTDY_diag, YTFY_diag,
-                                                                   XTY, XTDY, XTFY, X0TX0, X0TDX0, X0TFX0,
-                                                                   XTX0, XTDX0, XTFX0, X0TY, X0TDY, X0TFY,
-                                                                   np.log(
-                                                                       snr) * 2, l_idx, n_C, n_T, n_V, n_run, n_X0,
-                                                                   idx_param_fitU, n_C)[0], param0_fitU, vec)
-    assert np.isclose(dd, np.dot(
-        deriv0, vec), rtol=1e-5), 'gradient of fitU wrt to AR(1) coefficient incorrect'
+    dd = nd.directionaldiff(
+        lambda x: brsa._loglike_AR1_diagV_fitU(x, XTX, XTDX, XTFX, YTY_diag,
+                                               YTDY_diag, YTFY_diag, XTY, XTDY,
+                                               XTFY, X0TX0, X0TDX0, X0TFX0,
+                                               XTX0, XTDX0, XTFX0, X0TY, X0TDY,
+                                               X0TFY, np.log(snr) * 2, l_idx,
+                                               n_C, n_T, n_V, n_run, n_X0,
+                                               idx_param_fitU, n_C)[0],
+        param0_fitU,
+        vec)
+    assert np.isclose(dd, np.dot(deriv0, vec), rtol=1e-5), (
+        'gradient of fitU wrt to AR(1) coefficient incorrect')
 
     # We test if the numerical and analytical gradient wrt to the first
     # element of Cholesky factor is correct
     vec = np.zeros(np.size(param0_fitU))
     vec[idx_param_fitU['Cholesky'][0]] = 1
-    dd = nd.directionaldiff(lambda x: brsa._loglike_AR1_diagV_fitU(x, XTX, XTDX, XTFX, YTY_diag, YTDY_diag, YTFY_diag,
-                                                                   XTY, XTDY, XTFY, X0TX0, X0TDX0, X0TFX0,
-                                                                   XTX0, XTDX0, XTFX0, X0TY, X0TDY, X0TFY,
-                                                                   np.log(
-                                                                       snr) * 2, l_idx, n_C, n_T, n_V, n_run, n_X0,
-                                                                   idx_param_fitU, n_C)[0], param0_fitU, vec)
-    assert np.isclose(dd, np.dot(deriv0, vec),
-                      rtol=1e-5), 'gradient of fitU wrt Cholesky factor incorrect'
+    dd = nd.directionaldiff(
+        lambda x: brsa._loglike_AR1_diagV_fitU(x, XTX, XTDX, XTFX, YTY_diag,
+                                               YTDY_diag, YTFY_diag, XTY, XTDY,
+                                               XTFY, X0TX0, X0TDX0, X0TFX0,
+                                               XTX0, XTDX0, XTFX0, X0TY, X0TDY,
+                                               X0TFY, np.log(snr) * 2, l_idx,
+                                               n_C, n_T, n_V, n_run, n_X0,
+                                               idx_param_fitU, n_C)[0],
+        param0_fitU,
+        vec)
+    assert np.isclose(dd, np.dot(deriv0, vec), rtol=1e-5), (
+        'gradient of fitU wrt Cholesky factor incorrect')
 
     # Test on a random direction
     vec = np.random.randn(np.size(param0_fitU))
     vec = vec / np.linalg.norm(vec)
-    dd = nd.directionaldiff(lambda x: brsa._loglike_AR1_diagV_fitU(x, XTX, XTDX, XTFX, YTY_diag, YTDY_diag, YTFY_diag,
-                                                                   XTY, XTDY, XTFY, X0TX0, X0TDX0, X0TFX0,
-                                                                   XTX0, XTDX0, XTFX0, X0TY, X0TDY, X0TFY,
-                                                                   np.log(
-                                                                       snr) * 2, l_idx, n_C, n_T, n_V, n_run, n_X0,
-                                                                   idx_param_fitU, n_C)[0], param0_fitU, vec)
+    dd = nd.directionaldiff(
+        lambda x: brsa._loglike_AR1_diagV_fitU(x, XTX, XTDX, XTFX, YTY_diag,
+                                               YTDY_diag, YTFY_diag, XTY, XTDY,
+                                               XTFY, X0TX0, X0TDX0, X0TFX0,
+                                               XTX0, XTDX0, XTFX0, X0TY, X0TDY,
+                                               X0TFY, np.log(snr) * 2, l_idx,
+                                               n_C, n_T, n_V, n_run, n_X0,
+                                               idx_param_fitU, n_C)[0],
+        param0_fitU,
+        vec)
     assert np.isclose(dd, np.dot(deriv0, vec),
                       rtol=1e-5), 'gradient of fitU incorrect'
 
@@ -449,105 +507,117 @@ def test_gradient():
                                         XTX0, XTDX0, XTFX0,
                                         X0TY, X0TDY, X0TFY,
                                         L_full, rho1, n_V, n_X0)
-    assert np.shape(XTAcorrX) == (
-        n_V, n_C, n_C), 'Dimension of XTAcorrX is wrong by _precompute_ar1_quad_forms()'
-    assert XTAcorrY.shape == XTY.shape, 'Shape of XTAcorrY is wrong by _precompute_ar1_quad_forms()'
-    assert YTAcorrY.shape == YTY_diag.shape, 'Shape of YTAcorrY is wrong by _precompute_ar1_quad_forms()'
-    assert np.shape(X0TAX0) == (
-        n_V, n_X0, n_X0), 'Dimension of X0TAX0 is wrong by _precompute_ar1_quad_forms()'
-    assert np.shape(XTAX0) == (
-        n_V, n_C, n_X0), 'Dimension of XTAX0 is wrong by _precompute_ar1_quad_forms()'
-    assert X0TAY.shape == X0TY.shape, 'Shape of X0TAX0 is wrong by _precompute_ar1_quad_forms()'
-    assert np.all(np.isfinite(X0TAX0_i)
-                  ), 'Inverse of X0TAX0 includes NaN or Inf'
-    ll0, deriv0 = brsa._loglike_AR1_diagV_fitV(param0_fitV[idx_param_fitV['log_SNR2']],
-                                               X0TAX0, XTAX0, X0TAY,
-                                               X0TAX0_i, XTAcorrX, XTAcorrY, YTAcorrY,
-                                               LTXTAcorrY, XTAcorrXL, LTXTAcorrXL,
-                                               L_full[l_idx], np.tan(
-                                                   rho1 * np.pi / 2),
-                                               l_idx, n_C, n_T, n_V, n_run, n_X0,
-                                               idx_param_fitV, n_C, False, False)
+    assert np.shape(XTAcorrX) == (n_V, n_C, n_C), (
+        'Dimension of XTAcorrX is wrong by _precompute_ar1_quad_forms()')
+    assert XTAcorrY.shape == XTY.shape, (
+        'Shape of XTAcorrY is wrong by _precompute_ar1_quad_forms()')
+    assert YTAcorrY.shape == YTY_diag.shape, (
+        'Shape of YTAcorrY is wrong by _precompute_ar1_quad_forms()')
+    assert np.shape(X0TAX0) == (n_V, n_X0, n_X0), (
+        'Dimension of X0TAX0 is wrong by _precompute_ar1_quad_forms()')
+    assert np.shape(XTAX0) == (n_V, n_C, n_X0), (
+        'Dimension of XTAX0 is wrong by _precompute_ar1_quad_forms()')
+    assert X0TAY.shape == X0TY.shape, (
+        'Shape of X0TAX0 is wrong by _precompute_ar1_quad_forms()')
+    assert np.all(np.isfinite(X0TAX0_i)), (
+        'Inverse of X0TAX0 includes NaN or Inf')
+    ll0, deriv0 = brsa._loglike_AR1_diagV_fitV(
+        param0_fitV[idx_param_fitV['log_SNR2']], X0TAX0, XTAX0, X0TAY,
+        X0TAX0_i, XTAcorrX, XTAcorrY, YTAcorrY, LTXTAcorrY, XTAcorrXL,
+        LTXTAcorrXL, L_full[l_idx], np.tan(rho1 * np.pi / 2), l_idx, n_C, n_T,
+        n_V, n_run, n_X0, idx_param_fitV, n_C, False, False)
     vec = np.zeros(np.size(param0_fitV[idx_param_fitV['log_SNR2']]))
     vec[idx_param_fitV['log_SNR2'][0]] = 1
-    dd = nd.directionaldiff(lambda x: brsa._loglike_AR1_diagV_fitV(x, X0TAX0, XTAX0, X0TAY,
-                                                                   X0TAX0_i, XTAcorrX, XTAcorrY, YTAcorrY,
-                                                                   LTXTAcorrY, XTAcorrXL, LTXTAcorrXL,
-                                                                   L_full[l_idx], np.tan(
-                                                                       rho1 * np.pi / 2),
-                                                                   l_idx, n_C, n_T, n_V, n_run, n_X0,
-                                                                   idx_param_fitV, n_C, False, False)[0],
-                            param0_fitV[idx_param_fitV['log_SNR2']], vec)
-    assert np.isclose(dd, np.dot(
-        deriv0, vec), rtol=1e-5), 'gradient of fitV wrt log(SNR2) incorrect for model without GP'
+    dd = nd.directionaldiff(
+        lambda x: brsa._loglike_AR1_diagV_fitV(x, X0TAX0, XTAX0, X0TAY,
+                                               X0TAX0_i, XTAcorrX, XTAcorrY,
+                                               YTAcorrY, LTXTAcorrY, XTAcorrXL,
+                                               LTXTAcorrXL, L_full[l_idx],
+                                               np.tan(rho1 * np.pi / 2),
+                                               l_idx, n_C, n_T, n_V, n_run,
+                                               n_X0, idx_param_fitV, n_C,
+                                               False, False)[0],
+        param0_fitV[idx_param_fitV['log_SNR2']],
+        vec)
+    assert np.isclose(dd, np.dot(deriv0, vec), rtol=1e-5), (
+        'gradient of fitV wrt log(SNR2) incorrect for model without GP')
 
     # We test the gradient of _fitV wrt to log(SNR^2) assuming GP prior.
-    ll0, deriv0 = brsa._loglike_AR1_diagV_fitV(param0_fitV, X0TAX0, XTAX0, X0TAY,
-                                               X0TAX0_i, XTAcorrX, XTAcorrY, YTAcorrY,
-                                               LTXTAcorrY, XTAcorrXL, LTXTAcorrXL,
-                                               L_full[l_idx], np.tan(
-                                                   rho1 * np.pi / 2),
-                                               l_idx, n_C, n_T, n_V, n_run, n_X0,
-                                               idx_param_fitV, n_C, True, True,
-                                               dist2, inten_diff2, 100, 100)
+    ll0, deriv0 = brsa._loglike_AR1_diagV_fitV(
+        param0_fitV, X0TAX0, XTAX0, X0TAY, X0TAX0_i, XTAcorrX, XTAcorrY,
+        YTAcorrY, LTXTAcorrY, XTAcorrXL, LTXTAcorrXL, L_full[l_idx],
+        np.tan(rho1 * np.pi / 2), l_idx, n_C, n_T, n_V, n_run, n_X0,
+        idx_param_fitV, n_C, True, True, dist2, inten_diff2, 100, 100)
     vec = np.zeros(np.size(param0_fitV))
     vec[idx_param_fitV['log_SNR2'][0]] = 1
-    dd = nd.directionaldiff(lambda x: brsa._loglike_AR1_diagV_fitV(x, X0TAX0, XTAX0, X0TAY,
-                                                                   X0TAX0_i, XTAcorrX, XTAcorrY, YTAcorrY,
-                                                                   LTXTAcorrY, XTAcorrXL, LTXTAcorrXL,
-                                                                   L_full[l_idx], np.tan(
-                                                                       rho1 * np.pi / 2),
-                                                                   l_idx, n_C, n_T, n_V, n_run, n_X0,
-                                                                   idx_param_fitV, n_C, True, True,
-                                                                   dist2, inten_diff2,
-                                                                   100, 100)[0], param0_fitV, vec)
-    assert np.isclose(dd, np.dot(
-        deriv0, vec), rtol=1e-5), 'gradient of fitV srt log(SNR2) incorrect for model with GP'
+    dd = nd.directionaldiff(
+        lambda x: brsa._loglike_AR1_diagV_fitV(x, X0TAX0, XTAX0, X0TAY,
+                                               X0TAX0_i, XTAcorrX, XTAcorrY,
+                                               YTAcorrY, LTXTAcorrY, XTAcorrXL,
+                                               LTXTAcorrXL, L_full[l_idx],
+                                               np.tan(rho1 * np.pi / 2),
+                                               l_idx, n_C, n_T, n_V, n_run,
+                                               n_X0, idx_param_fitV, n_C, True,
+                                               True, dist2, inten_diff2, 100,
+                                               100)[0],
+        param0_fitV,
+        vec)
+    assert np.isclose(dd, np.dot(deriv0, vec), rtol=1e-5), (
+        'gradient of fitV srt log(SNR2) incorrect for model with GP')
 
     # We test the graident wrt spatial length scale parameter of GP prior
     vec = np.zeros(np.size(param0_fitV))
     vec[idx_param_fitV['c_space']] = 1
-    dd = nd.directionaldiff(lambda x: brsa._loglike_AR1_diagV_fitV(x, X0TAX0, XTAX0, X0TAY,
-                                                                   X0TAX0_i, XTAcorrX, XTAcorrY, YTAcorrY,
-                                                                   LTXTAcorrY, XTAcorrXL, LTXTAcorrXL,
-                                                                   L_full[l_idx], np.tan(
-                                                                       rho1 * np.pi / 2),
-                                                                   l_idx, n_C, n_T, n_V, n_run, n_X0,
-                                                                   idx_param_fitV, n_C, True, True,
-                                                                   dist2, inten_diff2,
-                                                                   100, 100)[0], param0_fitV, vec)
-    assert np.isclose(dd, np.dot(
-        deriv0, vec), rtol=1e-5), 'gradient of fitV wrt spatial length scale of GP incorrect'
+    dd = nd.directionaldiff(
+        lambda x: brsa._loglike_AR1_diagV_fitV(x, X0TAX0, XTAX0, X0TAY,
+                                               X0TAX0_i, XTAcorrX, XTAcorrY,
+                                               YTAcorrY, LTXTAcorrY, XTAcorrXL,
+                                               LTXTAcorrXL, L_full[l_idx],
+                                               np.tan(rho1 * np.pi / 2),
+                                               l_idx, n_C, n_T, n_V, n_run,
+                                               n_X0, idx_param_fitV, n_C, True,
+                                               True, dist2, inten_diff2, 100,
+                                               100)[0],
+        param0_fitV,
+        vec)
+    assert np.isclose(dd, np.dot(deriv0, vec), rtol=1e-5), (
+        'gradient of fitV wrt spatial length scale of GP incorrect')
 
     # We test the graident wrt intensity length scale parameter of GP prior
     vec = np.zeros(np.size(param0_fitV))
     vec[idx_param_fitV['c_inten']] = 1
-    dd = nd.directionaldiff(lambda x: brsa._loglike_AR1_diagV_fitV(x, X0TAX0, XTAX0, X0TAY,
-                                                                   X0TAX0_i, XTAcorrX, XTAcorrY, YTAcorrY,
-                                                                   LTXTAcorrY, XTAcorrXL, LTXTAcorrXL,
-                                                                   L_full[l_idx], np.tan(
-                                                                       rho1 * np.pi / 2),
-                                                                   l_idx, n_C, n_T, n_V, n_run, n_X0,
-                                                                   idx_param_fitV, n_C, True, True,
-                                                                   dist2, inten_diff2,
-                                                                   100, 100)[0], param0_fitV, vec)
-    assert np.isclose(dd, np.dot(
-        deriv0, vec), rtol=1e-5), 'gradient of fitV wrt intensity length scale of GP incorrect'
+    dd = nd.directionaldiff(
+        lambda x: brsa._loglike_AR1_diagV_fitV(x, X0TAX0, XTAX0, X0TAY,
+                                               X0TAX0_i, XTAcorrX, XTAcorrY,
+                                               YTAcorrY, LTXTAcorrY, XTAcorrXL,
+                                               LTXTAcorrXL, L_full[l_idx],
+                                               np.tan(rho1 * np.pi / 2),
+                                               l_idx, n_C, n_T, n_V, n_run,
+                                               n_X0, idx_param_fitV, n_C, True,
+                                               True, dist2, inten_diff2, 100,
+                                               100)[0],
+        param0_fitV,
+        vec)
+    assert np.isclose(dd, np.dot(deriv0, vec), rtol=1e-5), (
+        'gradient of fitV wrt intensity length scale of GP incorrect')
 
     # We test the graident on a random direction
     vec = np.random.randn(np.size(param0_fitV))
     vec = vec / np.linalg.norm(vec)
-    dd = nd.directionaldiff(lambda x: brsa._loglike_AR1_diagV_fitV(x, X0TAX0, XTAX0, X0TAY,
-                                                                   X0TAX0_i, XTAcorrX, XTAcorrY, YTAcorrY,
-                                                                   LTXTAcorrY, XTAcorrXL, LTXTAcorrXL,
-                                                                   L_full[l_idx], np.tan(
-                                                                       rho1 * np.pi / 2),
-                                                                   l_idx, n_C, n_T, n_V, n_run, n_X0,
-                                                                   idx_param_fitV, n_C, True, True,
-                                                                   dist2, inten_diff2,
-                                                                   100, 100)[0], param0_fitV, vec)
-    assert np.isclose(dd, np.dot(deriv0, vec),
-                      rtol=1e-5), 'gradient of fitV incorrect'
+    dd = nd.directionaldiff(
+        lambda x: brsa._loglike_AR1_diagV_fitV(x, X0TAX0, XTAX0, X0TAY,
+                                               X0TAX0_i, XTAcorrX, XTAcorrY,
+                                               YTAcorrY, LTXTAcorrY, XTAcorrXL,
+                                               LTXTAcorrXL, L_full[l_idx],
+                                               np.tan(rho1 * np.pi / 2),
+                                               l_idx, n_C, n_T, n_V, n_run,
+                                               n_X0, idx_param_fitV, n_C, True,
+                                               True, dist2, inten_diff2, 100,
+                                               100)[0],
+        param0_fitV,
+        vec)
+    assert np.isclose(dd, np.dot(deriv0, vec), rtol=1e-5), (
+        'gradient of fitV incorrect')
 
 
 def test_nureg_determine():
@@ -556,7 +626,8 @@ def test_nureg_determine():
     x = np.dot(np.random.randn(100, 5), np.random.randn(5, 40)) + \
         np.random.randn(100, 40) * 0.01
     ncomp = Ncomp_SVHT_MG_DLD_approx(x)
-    assert ncomp >= 3 and ncomp <= 8, 'recovered number of components should be in a reasonable range'
+    assert ncomp >= 3 and ncomp <= 8, (
+        'recovered number of components should be in a reasonable range')
 
 
 def test_half_log_det():
@@ -578,4 +649,5 @@ def test_n_nureg():
     design = np.random.randn(100, 2)
     s = brainiak.reprsimil.brsa.BRSA(n_iter=2)
     s.fit(X=noise, design=design)
-    assert s.n_nureg_ > 2 and s.n_nureg_ < 16, 'n_nureg_ estimation is wrong in BRSA'
+    assert s.n_nureg_ > 2 and s.n_nureg_ < 16, (
+        'n_nureg_ estimation is wrong in BRSA')

--- a/tests/searchlight/test_searchlight.py
+++ b/tests/searchlight/test_searchlight.py
@@ -16,7 +16,6 @@ from collections import namedtuple
 
 import numpy as np
 from mpi4py import MPI
-import sys
 
 from brainiak.searchlight.searchlight import Searchlight
 from brainiak.searchlight.searchlight import Diamond
@@ -24,36 +23,42 @@ from brainiak.searchlight.searchlight import Diamond
 """Distributed Searchlight Test
 """
 
+
 def cube_sfn(l, msk, myrad, bcast_var):
     if np.all(msk) and np.any(msk):
         return 1.0
     return None
+
 
 def test_searchlight_with_cube():
     sl = Searchlight(sl_rad=3)
     comm = MPI.COMM_WORLD
     rank = comm.rank
     size = comm.size
-    dim0, dim1, dim2 = (50,50,50)
+    dim0, dim1, dim2 = (50, 50, 50)
     ntr = 30
     nsubj = 3
-    mask = np.zeros((dim0,dim1,dim2), dtype=np.bool)
-    data = [np.empty((dim0,dim1,dim2,ntr), dtype=np.object) if i % size == rank else None for i in range(0, nsubj)]
+    mask = np.zeros((dim0, dim1, dim2), dtype=np.bool)
+    data = [np.empty((dim0, dim1, dim2, ntr), dtype=np.object)
+            if i % size == rank
+            else None
+            for i in range(0, nsubj)]
 
     # Put a spot in the mask
-    mask[10:17,10:17,10:17] = True
+    mask[10:17, 10:17, 10:17] = True
 
     sl.distribute(data, mask)
     global_outputs = sl.run_searchlight(cube_sfn)
 
     if rank == 0:
-        assert global_outputs[13,13,13] == 1.0
-        global_outputs[13,13,13] = None
+        assert global_outputs[13, 13, 13] == 1.0
+        global_outputs[13, 13, 13] = None
 
         for i in range(global_outputs.shape[0]):
             for j in range(global_outputs.shape[1]):
                 for k in range(global_outputs.shape[2]):
-                    assert global_outputs[i,j,k] == None
+                    assert global_outputs[i, j, k] is None
+
 
 def diamond_sfn(l, msk, myrad, bcast_var):
     assert not np.any(msk[~Diamond(3).mask_])
@@ -61,38 +66,43 @@ def diamond_sfn(l, msk, myrad, bcast_var):
         return 1.0
     return None
 
+
 def test_searchlight_with_diamond():
     sl = Searchlight(sl_rad=3, shape=Diamond)
     comm = MPI.COMM_WORLD
     rank = comm.rank
     size = comm.size
-    dim0, dim1, dim2 = (50,50,50)
+    dim0, dim1, dim2 = (50, 50, 50)
     ntr = 30
     nsubj = 3
-    mask = np.zeros((dim0,dim1,dim2), dtype=np.bool)
-    data = [np.empty((dim0,dim1,dim2,ntr), dtype=np.object) if i % size == rank else None for i in range(0, nsubj)]
+    mask = np.zeros((dim0, dim1, dim2), dtype=np.bool)
+    data = [np.empty((dim0, dim1, dim2, ntr), dtype=np.object)
+            if i % size == rank
+            else None
+            for i in range(0, nsubj)]
 
     # Put a spot in the mask
-    mask[10:17,10:17,10:17] = Diamond(3).mask_
+    mask[10:17, 10:17, 10:17] = Diamond(3).mask_
 
     sl.distribute(data, mask)
     global_outputs = sl.run_searchlight(diamond_sfn)
 
     if rank == 0:
-        assert global_outputs[13,13,13] == 1.0
-        global_outputs[13,13,13] = None
+        assert global_outputs[13, 13, 13] == 1.0
+        global_outputs[13, 13, 13] = None
 
         for i in range(global_outputs.shape[0]):
             for j in range(global_outputs.shape[1]):
                 for k in range(global_outputs.shape[2]):
-                    assert global_outputs[i,j,k] == None
+                    assert global_outputs[i, j, k] is None
+
 
 MaskRadBcast = namedtuple("MaskRadBcast", "mask rad")
 
 
 def test_instantiate():
-  sl = Searchlight(sl_rad=5, max_blk_edge=10)
-  assert sl
+    sl = Searchlight(sl_rad=5, max_blk_edge=10)
+    assert sl
 
 
 def voxel_test_sfn(l, msk, myrad, bcast):
@@ -124,89 +134,91 @@ def voxel_test_sfn(l, msk, myrad, bcast):
     return midpt
 
 
-def block_test_sfn(l,msk,myrad,bcast_var, extra_params):
-  outmat = l[0][:,:,:,0] 
-  outmat[~msk] = None
-  return outmat[myrad:-myrad,myrad:-myrad,myrad:-myrad] 
+def block_test_sfn(l, msk, myrad, bcast_var, extra_params):
+    outmat = l[0][:, :, :, 0]
+    outmat[~msk] = None
+    return outmat[myrad:-myrad, myrad:-myrad, myrad:-myrad]
 
 
-def test_correctness():
-  def voxel_test(data, mask, max_blk_edge, rad):
-    
-    comm = MPI.COMM_WORLD
-    rank = comm.rank
-    size = comm.size
-    
-    nsubj = len(data)
-    (dim0, dim1, dim2) = mask.shape
-    
-    # Initialize dataset with known pattern
-    for subj in data:
-      if subj is not None:
-        for tr in range(subj.shape[3]):
-          for d1 in range(dim0):
-            for d2 in range(dim1):
-              for d3 in range(dim2): 
-                subj[d1,d2,d3,tr] = np.array([d1, d2, d3, tr])
-    
-    sl = Searchlight(sl_rad=rad, max_blk_edge=max_blk_edge)
-    sl.distribute(data, mask)
-    sl.broadcast(MaskRadBcast(mask, rad))
-    global_outputs = sl.run_searchlight(voxel_test_sfn)
-  
-    if rank == 0:
-      for d0 in range(rad, global_outputs.shape[0]-rad):
-        for d1 in range(rad, global_outputs.shape[1]-rad):
-          for d2 in range(rad, global_outputs.shape[2]-rad):
-              if mask[d0, d1, d2]:
-                  assert np.array_equal(np.array(global_outputs[d0,d1,d2]), np.array([d0,d1,d2]))
-  
-  
-  def block_test(data, mask, max_blk_edge, rad):
-    
-    comm = MPI.COMM_WORLD
-    rank = comm.rank
-    size = comm.size
-    
-    nsubj = len(data)
-    (dim0, dim1, dim2) = mask.shape
-    
-    # Initialize dataset with known pattern
-    for subj in data:
-      if subj is not None:
-        for tr in range(subj.shape[3]):
-          for d1 in range(dim0):
-            for d2 in range(dim1):
-              for d3 in range(dim2): 
-                subj[d1,d2,d3,tr] = np.array([ d1, d2, d3, tr])
-    
-    sl = Searchlight(sl_rad=rad, max_blk_edge=max_blk_edge)
-    sl.distribute(data, mask)
-    sl.broadcast(mask)
-    global_outputs = sl.run_block_function(block_test_sfn)
-  
-    if rank == 0:
-      for d0 in range(rad, global_outputs.shape[0]-rad):
-        for d1 in range(rad, global_outputs.shape[1]-rad):
-          for d2 in range(rad, global_outputs.shape[2]-rad):
-            if mask[d0, d1, d2]:
-              assert np.array_equal(np.array(global_outputs[d0,d1,d2]), np.array([d0,d1,d2,0]))
-  
-  # Create dataset
-  def do_test(dim0, dim1, dim2, ntr, nsubj, max_blk_edge, rad):
-    comm = MPI.COMM_WORLD
-    rank = comm.rank
-    size = comm.size
-    mask = np.random.choice([True, False], (dim0,dim1,dim2))
-    data = [np.empty((dim0,dim1,dim2,ntr), dtype=np.object) if i % size == rank else None for i in range(0, nsubj)]
-    voxel_test(data, mask, max_blk_edge, rad)
-    block_test(data, mask, max_blk_edge, rad)
-  
-  
-  do_test(dim0=7, dim1=5, dim2=9, ntr=5, nsubj=1, max_blk_edge=4, rad=1)
-  do_test(dim0=7, dim1=5, dim2=9, ntr=5, nsubj=5, max_blk_edge=4, rad=1)
-  do_test(dim0=1, dim1=5, dim2=9, ntr=5, nsubj=5, max_blk_edge=4, rad=1)
-  do_test(dim0=0, dim1=10, dim2=8, ntr=5, nsubj=5, max_blk_edge=4, rad=1)
-  do_test(dim0=7, dim1=5, dim2=9, ntr=5, nsubj=1, max_blk_edge=4, rad=2)
-  do_test(dim0=7, dim1=5, dim2=9, ntr=5, nsubj=1, max_blk_edge=4, rad=3)
+def test_correctness():  # noqa: C901
+    def voxel_test(data, mask, max_blk_edge, rad):
 
+        comm = MPI.COMM_WORLD
+        rank = comm.rank
+
+        (dim0, dim1, dim2) = mask.shape
+
+        # Initialize dataset with known pattern
+        for subj in data:
+            if subj is not None:
+                for tr in range(subj.shape[3]):
+                    for d1 in range(dim0):
+                        for d2 in range(dim1):
+                            for d3 in range(dim2):
+                                subj[d1, d2, d3, tr] = np.array(
+                                    [d1, d2, d3, tr])
+
+        sl = Searchlight(sl_rad=rad, max_blk_edge=max_blk_edge)
+        sl.distribute(data, mask)
+        sl.broadcast(MaskRadBcast(mask, rad))
+        global_outputs = sl.run_searchlight(voxel_test_sfn)
+
+        if rank == 0:
+            for d0 in range(rad, global_outputs.shape[0]-rad):
+                for d1 in range(rad, global_outputs.shape[1]-rad):
+                    for d2 in range(rad, global_outputs.shape[2]-rad):
+                        if mask[d0, d1, d2]:
+                            assert np.array_equal(
+                                np.array(global_outputs[d0, d1, d2]),
+                                np.array([d0, d1, d2]))
+
+    def block_test(data, mask, max_blk_edge, rad):
+
+        comm = MPI.COMM_WORLD
+        rank = comm.rank
+
+        (dim0, dim1, dim2) = mask.shape
+
+        # Initialize dataset with known pattern
+        for subj in data:
+            if subj is not None:
+                for tr in range(subj.shape[3]):
+                    for d1 in range(dim0):
+                        for d2 in range(dim1):
+                            for d3 in range(dim2):
+                                subj[d1, d2, d3, tr] = np.array(
+                                    [d1, d2, d3, tr])
+
+        sl = Searchlight(sl_rad=rad, max_blk_edge=max_blk_edge)
+        sl.distribute(data, mask)
+        sl.broadcast(mask)
+        global_outputs = sl.run_block_function(block_test_sfn)
+
+        if rank == 0:
+            for d0 in range(rad, global_outputs.shape[0]-rad):
+                for d1 in range(rad, global_outputs.shape[1]-rad):
+                    for d2 in range(rad, global_outputs.shape[2]-rad):
+                        if mask[d0, d1, d2]:
+                            assert np.array_equal(
+                                np.array(global_outputs[d0, d1, d2]),
+                                np.array([d0, d1, d2, 0]))
+
+    # Create dataset
+    def do_test(dim0, dim1, dim2, ntr, nsubj, max_blk_edge, rad):
+        comm = MPI.COMM_WORLD
+        rank = comm.rank
+        size = comm.size
+        mask = np.random.choice([True, False], (dim0, dim1, dim2))
+        data = [np.empty((dim0, dim1, dim2, ntr), dtype=np.object)
+                if i % size == rank
+                else None
+                for i in range(0, nsubj)]
+        voxel_test(data, mask, max_blk_edge, rad)
+        block_test(data, mask, max_blk_edge, rad)
+
+    do_test(dim0=7, dim1=5, dim2=9, ntr=5, nsubj=1, max_blk_edge=4, rad=1)
+    do_test(dim0=7, dim1=5, dim2=9, ntr=5, nsubj=5, max_blk_edge=4, rad=1)
+    do_test(dim0=1, dim1=5, dim2=9, ntr=5, nsubj=5, max_blk_edge=4, rad=1)
+    do_test(dim0=0, dim1=10, dim2=8, ntr=5, nsubj=5, max_blk_edge=4, rad=1)
+    do_test(dim0=7, dim1=5, dim2=9, ntr=5, nsubj=1, max_blk_edge=4, rad=2)
+    do_test(dim0=7, dim1=5, dim2=9, ntr=5, nsubj=1, max_blk_edge=4, rad=3)

--- a/tests/utils/test_fmrisim.py
+++ b/tests/utils/test_fmrisim.py
@@ -43,8 +43,8 @@ def test_generate_signal():
 
     assert np.all(volume.shape == dimensions), "Check signal shape"
     assert np.max(volume) == signal_magnitude, "Check signal magnitude"
-    assert np.sum(volume>0) == math.pow(feature_size[0], 3), "Check feature " \
-                                                             "size"
+    assert np.sum(volume > 0) == math.pow(feature_size[0], 3), (
+        "Check feature size")
     assert volume[5, 5, 5] == signal_magnitude, "Check signal location"
     assert volume[5, 5, 1] == 0, "Check noise location"
 
@@ -55,8 +55,7 @@ def test_generate_signal():
                                  feature_coordinates=feature_coordinates,
                                  feature_type=['loop', 'cavity', 'sphere'],
                                  feature_size=[3],
-                                 signal_magnitude=signal_magnitude,
-                                )
+                                 signal_magnitude=signal_magnitude)
     assert volume[5, 5, 5] == 0, "Loop is empty"
     assert volume[3, 3, 3] == 0, "Cavity is empty"
     assert volume[7, 7, 7] != 0, "Sphere is not empty"
@@ -212,7 +211,7 @@ def test_generate_noise():
                                noise_dict={'temporal_noise': 0, 'sfnr': 10000},
                                )
 
-    temporal_noise = np.std(noise[mask[:,:,:,0]>0],1).mean()
+    temporal_noise = np.std(noise[mask[:, :, :, 0] > 0], 1).mean()
 
     assert temporal_noise <= 0.1, "Noise strength could not be manipulated"
 
@@ -220,7 +219,7 @@ def test_generate_noise():
 def test_mask_brain():
 
     # Inputs for generate_signal
-    dimensions = np.array([10, 10, 10]) # What is the size of the brain
+    dimensions = np.array([10, 10, 10])  # What is the size of the brain
     feature_size = [2]
     feature_type = ['cube']
     feature_coordinates = np.array(
@@ -254,7 +253,7 @@ def test_mask_brain():
                                  )
 
     # Mask the volume to be the same shape as a brain
-    mask = sim.mask_brain(volume)[:,:,:,0]
+    mask = sim.mask_brain(volume)[:, :, :, 0]
     brain = volume * (mask > 0)
 
     assert np.sum(brain != 0) < np.sum(volume != 0), "Masking did not work"

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -11,7 +11,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-import pytest
 
 
 def test_tri_sym_convert():
@@ -34,12 +33,16 @@ def test_sumexp():
     from brainiak.utils.utils import sumexp_stable
     import numpy as np
 
-    data = np.array([[1, 1],[0, 1]])
+    data = np.array([[1, 1], [0, 1]])
     sums, maxs, exps = sumexp_stable(data)
-    assert sums.size == data.shape[1], "Invalid sum(exp(v)) computation (wrong # samples in sums)"
-    assert exps.shape[0] == data.shape[0], "Invalid exp(v) computation (wrong # features)"
-    assert exps.shape[1] == data.shape[1], "Invalid exp(v) computation (wrong # samples)"
-    assert maxs.size == data.shape[1], "Invalid max computation (wrong # samples in maxs)"
+    assert sums.size == data.shape[1], (
+        "Invalid sum(exp(v)) computation (wrong # samples in sums)")
+    assert exps.shape[0] == data.shape[0], (
+        "Invalid exp(v) computation (wrong # features)")
+    assert exps.shape[1] == data.shape[1], (
+        "Invalid exp(v) computation (wrong # samples)")
+    assert maxs.size == data.shape[1], (
+        "Invalid max computation (wrong # samples in maxs)")
 
 
 def test_concatenate_not_none():
@@ -52,16 +55,18 @@ def test_concatenate_not_none():
 
     r = concatenate_not_none(l, axis=0)
 
-    assert np.all(np.arange(5) == r), "Invalid concatenation of a list of arrays"
+    assert np.all(np.arange(5) == r), (
+        "Invalid concatenation of a list of arrays")
 
 
 def test_cov2corr():
     from brainiak.utils.utils import cov2corr
     import numpy as np
-    cov = np.array([[4,3,0],[3,9,0],[0,0,1]])
+    cov = np.array([[4, 3, 0], [3, 9, 0], [0, 0, 1]])
     corr = cov2corr(cov)
-    assert np.isclose(corr, np.array([[1,0.5,0],[0.5,1,0],[0,0,1]])).all(),\
-        "Converting from covariance matrix to correlation incorrect"
+    assert np.allclose(corr,
+                       np.array([[1, 0.5, 0], [0.5, 1, 0], [0, 0, 1]])), (
+        "Converting from covariance matrix to correlation incorrect")
 
 
 def test_ReadDesign():
@@ -69,7 +74,8 @@ def test_ReadDesign():
     import numpy as np
     import os.path
     file_path = os.path.join(os.path.dirname(__file__), "example_design.1D")
-    design = ReadDesign(fname=file_path, include_orth=False, include_pols=False)
+    design = ReadDesign(fname=file_path, include_orth=False,
+                        include_pols=False)
     assert design, 'Failed to read design matrix'
     assert design.reg_nuisance is None, \
         'Nuiance regressor is not None when include_orth and include_pols are'\
@@ -81,9 +87,10 @@ def test_ReadDesign():
         'Mistake in counting the number of nuiance regressors'
     assert np.size(design.cols_task) == 17, \
         'Mistake in counting the number of task conditions'
-    assert np.shape(design.reg_nuisance)[0] == np.shape(design.design_task)[0],\
-        'The number of time points in nuiance regressor does not match'\
-        ' that of task response'
+    assert (np.shape(design.reg_nuisance)[0]
+            == np.shape(design.design_task)[0]
+            ), 'The number of time points in nuiance regressor does not match'\
+               ' that of task response'
 
 
 def test_gen_design():
@@ -92,21 +99,32 @@ def test_gen_design():
     import os.path
     files = {'FSL1': 'example_stimtime_1_FSL.txt',
              'FSL2': 'example_stimtime_2_FSL.txt',
-             'AFNI1':'example_stimtime_1_AFNI.txt'}
+             'AFNI1': 'example_stimtime_1_AFNI.txt'}
     for key in files.keys():
         files[key] = os.path.join(os.path.dirname(__file__), files[key])
-    design1 = gen_design(stimtime_files=files['FSL1'], scan_duration=[48, 20], TR=2, style='FSL')
+    design1 = gen_design(stimtime_files=files['FSL1'], scan_duration=[48, 20],
+                         TR=2, style='FSL')
     assert design1.shape == (34, 1), 'Returned design matrix has wrong shape'
-    assert design1[24] == 0, 'gen_design should generated design matrix for each run separately and concatenate them.'
+    assert design1[24] == 0, (
+        "gen_design should generated design matrix for each run separately "
+        "and concatenate them.")
     design2 = gen_design(stimtime_files=[files['FSL1'], files['FSL2']],
-                        scan_duration=[48, 20], TR=2, style='FSL')
+                         scan_duration=[48, 20], TR=2, style='FSL')
     assert design2.shape == (34, 2), 'Returned design matrix has wrong shape'
-    design3 = gen_design(stimtime_files=files['FSL1'], scan_duration=68, TR=2, style='FSL')
-    assert design3[24] != 0, 'design matrix should be non-zero 8 seconds after an event onset.'
-    design4 = gen_design(stimtime_files=[files['FSL2']], scan_duration=[48, 20], TR=2, style='FSL')
-    assert np.all(np.isclose(design1 * 0.5, design4)) , 'gen_design does not treat missing values correctly'
-    design5 = gen_design(stimtime_files=[files['FSL2']], scan_duration=[48, 20], TR=1)
-    assert np.all(np.isclose(design4, design5[::2])) , 'design matrices sampled at different frequency do not match'\
-        ' at corresponding time points'
-    design6 = gen_design(stimtime_files=[files['AFNI1']], scan_duration=[48, 20], TR=2, style='AFNI')
-    assert np.all(np.isclose(design1, design6)), 'design matrices generated from AFNI style and FSL style do not match'
+    design3 = gen_design(stimtime_files=files['FSL1'], scan_duration=68, TR=2,
+                         style='FSL')
+    assert design3[24] != 0, (
+        'design matrix should be non-zero 8 seconds after an event onset.')
+    design4 = gen_design(stimtime_files=[files['FSL2']],
+                         scan_duration=[48, 20], TR=2, style='FSL')
+    assert np.all(np.isclose(design1 * 0.5, design4)), (
+        'gen_design does not treat missing values correctly')
+    design5 = gen_design(stimtime_files=[files['FSL2']],
+                         scan_duration=[48, 20], TR=1)
+    assert np.all(np.isclose(design4, design5[::2])), (
+        'design matrices sampled at different frequency do not match'
+        ' at corresponding time points')
+    design6 = gen_design(stimtime_files=[files['AFNI1']],
+                         scan_duration=[48, 20], TR=2, style='AFNI')
+    assert np.all(np.isclose(design1, design6)), (
+        'design matrices generated from AFNI style and FSL style do not match')


### PR DESCRIPTION
Because we allow `print` in test code, I had to explicitly list the code
we want flake8 to ignore. I think this is better in the long run anyway.

I changed most of the tests to comply. However, I did add a few `noqa`
markers, mostly for complexity. I will make separate issues for each
package for removing them.

Partially addresses #19.