### PR TITLE
small fixes after Hackathon at UT Austin

### DIFF
--- a/brainiak/fcma/voxelselector.py
+++ b/brainiak/fcma/voxelselector.py
@@ -94,11 +94,16 @@ class VoxelSelector:
         the number of hardware threads,
         i.e. the number returned by cpu_count().
         If 0, cross validation will not use python multiprocessing.
-        NOTE: on some compute cluster, python multiprocessing launched
-        via MPI on a remote machine may result in child processes disfunct.
 
     master_rank: int, default 0
         The process which serves as the master
+
+    Note
+    ----
+
+        On some compute cluster (e.g. lonestar5 at TACC),
+        python multiprocessing launched
+        via MPI on a remote machine may result in child processes defunct.
     """
     def __init__(self,
                  labels,
@@ -118,7 +123,7 @@ class VoxelSelector:
         self.num_voxels2 = raw_data2[0].shape[1] \
             if raw_data2 is not None else self.num_voxels
         self.voxel_unit = voxel_unit
-        self.process_num = process_num
+        self.process_num = np.min((process_num, multiprocessing.cpu_count()))
         if self.process_num == 0:
             self.use_multiprocessing = False
         else:

--- a/brainiak/fcma/voxelselector.py
+++ b/brainiak/fcma/voxelselector.py
@@ -97,13 +97,6 @@ class VoxelSelector:
 
     master_rank: int, default 0
         The process which serves as the master
-
-    Note
-    ----
-
-        On some compute cluster (e.g. lonestar5 at TACC),
-        python multiprocessing launched
-        via MPI on a remote machine may result in child processes defunct.
     """
     def __init__(self,
                  labels,

--- a/examples/fcma/run_mvpa_voxel_selection.sh
+++ b/examples/fcma/run_mvpa_voxel_selection.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
+
+# make sure OMP_NUM_THREADS is specified
+
 mpirun -np 1 python3 mvpa_voxel_selection.py face_scene bet.nii.gz face_scene/visual_top_mask.nii.gz face_scene/fs_epoch_labels.npy 18

--- a/examples/fcma/run_voxel_selection.sh
+++ b/examples/fcma/run_voxel_selection.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+# make sure OMP_NUM_THREADS is specified
+
 mpirun -np 2 python3 voxel_selection.py face_scene bet.nii.gz face_scene/mask.nii.gz face_scene/fs_epoch_labels.npy 12 18

--- a/tests/fcma/test_voxel_selection.py
+++ b/tests/fcma/test_voxel_selection.py
@@ -46,14 +46,14 @@ def test_voxel_selection():
     fake_corr = prng.rand(1, 4, 5).astype(np.float32)
     fake_corr = vs._correlation_normalization(fake_corr)
     if MPI.COMM_WORLD.Get_rank() == 0:
-        expected_fake_corr = [[[1.19203866, 0.18862808, -0.54350245,
-                                -1.18334889, -0.16860008],
-                               [-1.06594729, -1.08742261, -1.19447124,
-                                1.14114654, -0.67860204],
-                               [0.7839641, 1.53981364, 0.24948341,
-                                0.82626557, 1.67902875],
-                               [-0.91005552, -0.64101928, 1.48848987,
-                                -0.78406328, -0.83182675]]]
+        expected_fake_corr = [[[1.06988919, 0.51641309, -0.46790636,
+                                -1.31926763, 0.2270218],
+                               [-1.22142744, -1.39881694, -1.2979387,
+                                1.05702305, -0.6525566],
+                               [0.89795232, 1.27406132, 0.36460185,
+                                0.87538344, 1.5227468],
+                               [-0.74641371, -0.39165771, 1.40124381,
+                                -0.61313909, -1.0972116]]]
         assert np.allclose(fake_corr, expected_fake_corr), \
             'within-subject normalization does not provide correct results'
     # for cross validation, use SVM with precomputed kernel


### PR DESCRIPTION
1. change process_num default value to be more conservative; 
2. add notes for possible Python multiprocessing error (happened on Lonestar5 of TACC)
3. fix a bug in the Python version of correlation normalization